### PR TITLE
newer jai-imageio-core, remove myGrid repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,6 @@ repositories {
         name = 'JBoss repository' // required to obtain non-free JAI
         url = 'https://repository.jboss.org/nexus/content/repositories/thirdparty-releases'
     }
-    maven {
-        name = 'MyGrid Repository'
-        url = 'http://www.mygrid.org.uk/maven/repository'
-    }
     mavenLocal()
     //flatDir(dirs: 'dev/externals') // for libraries not in any other repository
 }
@@ -96,7 +92,7 @@ dependencies {
         [group: 'org.bytedeco', name: 'javacpp', version: '1.3'],
         [group: 'org.bytedeco.javacpp-presets', name: 'leptonica', version: '1.73-1.3'],
         [group: 'org.bytedeco.javacpp-presets', name: 'tesseract', version: '3.04.01-1.3'],
-        [group: 'net.java.dev.jai-imageio', name: 'jai-imageio-core-standalone', version: '1.2-pre-dr-b04-2014-09-13'],
+        [group: 'com.github.jai-imageio', name: 'jai-imageio-core', version: '1.3.1'],
         [group: 'org.deeplearning4j', name: 'deeplearning4j-core', version: "${project.ext.dl4jVersion}"],
         [group: 'org.deeplearning4j', name: 'deeplearning4j-ui_2.10', version: "${project.ext.dl4jVersion}"],
         [group: 'org.nd4j', name: 'nd4j-native', version: "${project.ext.nd4jVersion}"]

--- a/src/main/org/audiveris/omr/text/tesseract/TesseractOrder.java
+++ b/src/main/org/audiveris/omr/text/tesseract/TesseractOrder.java
@@ -72,9 +72,9 @@ public class TesseractOrder
     static {
         IIORegistry registry = IIORegistry.getDefaultInstance();
         registry.registerServiceProvider(
-                new com.sun.media.imageioimpl.plugins.tiff.TIFFImageWriterSpi());
+                new com.github.jaiimageio.impl.plugins.tiff.TIFFImageWriterSpi());
         registry.registerServiceProvider(
-                new com.sun.media.imageioimpl.plugins.tiff.TIFFImageReaderSpi());
+                new com.github.jaiimageio.impl.plugins.tiff.TIFFImageReaderSpi());
     }
 
     //~ Instance fields ----------------------------------------------------------------------------


### PR DESCRIPTION
..as it moved to https://github.com/jai-imageio/jai-imageio-core/
and now lives properly in Maven Central/jcenter.

Internal package name changed to `com.github.jaiimageio.impl`
(TODO: `TesseractOrder` shouldn't use those hard-coded anyway)

NOTE: JPEG2000 support is not included, that moved to
https://github.com/jai-imageio/jai-imageio-jpeg2000 as that code
was NOT GPL3 compatible.


(I must admit I've not tested it as the build still takes a long time..)