### PR TITLE
Update README with JDK version instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Full GUIs, meant for the end-user, are expected to be provided by external edito
 First of all, you'll need the following dependencies installed and working from
 the command line:
 
-+ [Java Development Kit (JDK) version 7 or later (version 8 is recommended)][1].
++ [Java Development Kit (JDK) version 7 or 8 (version 8 is recommended; version 9 is not yet supported)][1].
   **Please ensure you're running a 64-bit JVM. Audiveris doesn't support a 32-bit
   JVM because deeplearning4j is 64-bit only.**
 + [Git](https://git-scm.com) version control system.


### PR DESCRIPTION
Audiveris won't build if you're using JDK version 9. The dependency Lombok throws a NullPointerException, which appears to be caused by it not yet supporting JDK 9: https://github.com/rzwitserloot/lombok/issues/985

In my case, uninstalling JDK  9 and switching to JDK 8 worked perfectly and allowed me to build/run Audiveris.