### PR TITLE
Fix dependencies for Java 9.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,11 @@ dependencies {
         [group: 'com.github.jai-imageio', name: 'jai-imageio-core', version: '1.3.1'],
         [group: 'org.deeplearning4j', name: 'deeplearning4j-core', version: "${project.ext.dl4jVersion}"],
         [group: 'org.nd4j', name: 'nd4j-native', version: "${project.ext.nd4jVersion}"],
-        [group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.4']
+        [group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.4'],
+        [group: 'javax.activation', name: 'activation', version: '1.1.1'],
+        [group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.11'],
+        [group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.2.11'],
+        [group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.2.11']
     )
 
     runtime(

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,12 @@
-apply plugin: 'java'
-apply plugin: 'application'
+plugins {
+    id 'java'
+    id 'application'
+    id 'io.franzbecker.gradle-lombok' version '1.11'
+}
+
+lombok {
+    version = '1.16.20'
+}
 
 sourceCompatibility = '1.7'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'


### PR DESCRIPTION
1) Starting with Java 9, Java EE APIs are no longer contained on the default class path, so we have to depend on them explicitly.
2) Old versions of lombok don't work with Java 9 → require current stable version (1.16.20).