### PR TITLE
Fixed missing reference for javadoc compliation.

### DIFF
--- a/src/main/org/audiveris/omr/sig/relation/MirrorRelation.java
+++ b/src/main/org/audiveris/omr/sig/relation/MirrorRelation.java
@@ -21,6 +21,8 @@
 // </editor-fold>
 package org.audiveris.omr.sig.relation;
 
+import org.audiveris.omr.sig.inter.AbstractInter;
+
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**


### PR DESCRIPTION
When updating the [AUR](https://aur.archlinux.org/packages/audiveris) package I made, the `gradle javadoc` command failed because it couldn't find that particular reference. Please consider merging this into the master branch.

良いお年を
Happy new year ^^