### PR TITLE
Adds arm architecture to build script.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext.targetOSName   = System.getProperty('os.name').toLowerCase()\
                      .startsWith('mac os x') ? 'macosx' :\
                      System.getProperty('os.name').split(' ')[0].toLowerCase()
 ext.targetOSArch   = ["i386":"x86", "i486":"x86", "i586":"x86", "i686":"x86", "x86":"x86",
-                      "amd64":"x86_64", "x86-64":"x86_64", "x86_64":"x86_64"]\
+                      "amd64":"x86_64", "x86-64":"x86_64", "x86_64":"x86_64", "arm":"armhf"]\
                      [System.getProperty('os.arch').toLowerCase()]
 ext.targetOS       = "${project.ext.targetOSName}-${project.ext.targetOSArch}"
 println "targetOS=${project.ext.targetOS}"


### PR DESCRIPTION
On Raspberry Pi 4, the architecture is reported as arm.
This was not handled by the build script, causing "none" to
be inserted instead of "armhf" when getting dependencies.