### PR TITLE
First steps recognizing diamond (filled & hollow) drum noteheads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ data/www/docs/guides
 private/*
 schemas/build
 schemas/build/*
+schemas/bin
 target/*
 \.orig\..*$
 \.orig$

--- a/src/main/org/audiveris/omr/glyph/Shape.java
+++ b/src/main/org/audiveris/omr/glyph/Shape.java
@@ -317,10 +317,12 @@ public enum Shape
     //
     // Noteheads ---
     //
-    NOTEHEAD_CROSS("Ghost node with rhythmic value but no discernible pitch"),
-    NOTEHEAD_BLACK("Filled node head for quarters and less"),
+    NOTEHEAD_CROSS("Ghost note with rhythmic value but no discernible pitch"),
+    NOTEHEAD_DIAMOND_FILLED("Filled diamond shape note head for unpitched percussion"),
+    NOTEHEAD_DIAMOND_VOID("Hollow diamond shape note head for unpitched percussion"),
+    NOTEHEAD_BLACK("Filled note head for quarters and less"),
     NOTEHEAD_BLACK_SMALL("Small filled note head for grace or cue"),
-    NOTEHEAD_VOID("Hollow node head for halves"),
+    NOTEHEAD_VOID("Hollow note head for halves"),
     NOTEHEAD_VOID_SMALL("Small hollow note head for grace or cue"),
 
     //

--- a/src/main/org/audiveris/omr/glyph/ShapeSet.java
+++ b/src/main/org/audiveris/omr/glyph/ShapeSet.java
@@ -172,11 +172,13 @@ public class ShapeSet
 
     /** All black note heads. */
     public static final EnumSet<Shape> BlackNoteHeads = EnumSet.of(
+            NOTEHEAD_DIAMOND_FILLED,
             NOTEHEAD_BLACK,
             NOTEHEAD_BLACK_SMALL);
 
     /** All void note heads. */
     public static final EnumSet<Shape> VoidNoteHeads = EnumSet.of(
+            NOTEHEAD_DIAMOND_VOID,
             NOTEHEAD_VOID,
             NOTEHEAD_VOID_SMALL);
 
@@ -195,6 +197,8 @@ public class ShapeSet
     /** All heads with a stem. */
     public static final EnumSet<Shape> StemHeads = EnumSet.of(
             NOTEHEAD_CROSS,
+            NOTEHEAD_DIAMOND_FILLED,
+            NOTEHEAD_DIAMOND_VOID,
             NOTEHEAD_BLACK,
             NOTEHEAD_BLACK_SMALL,
             NOTEHEAD_VOID,
@@ -206,6 +210,8 @@ public class ShapeSet
             WHOLE_NOTE,
             WHOLE_NOTE_SMALL,
             NOTEHEAD_CROSS,
+            NOTEHEAD_DIAMOND_FILLED,
+            NOTEHEAD_DIAMOND_VOID,
             NOTEHEAD_BLACK,
             NOTEHEAD_BLACK_SMALL,
             NOTEHEAD_VOID,
@@ -765,6 +771,8 @@ public class ShapeSet
     public static EnumSet<Shape> getTemplateNotes (Sheet sheet)
     {
         final EnumSet<Shape> set = EnumSet.of(
+                NOTEHEAD_DIAMOND_FILLED,
+                NOTEHEAD_DIAMOND_VOID,
                 NOTEHEAD_CROSS,
                 NOTEHEAD_BLACK,
                 NOTEHEAD_VOID,
@@ -791,8 +799,11 @@ public class ShapeSet
             set.remove(WHOLE_NOTE_SMALL);
         }
 
+        /** For now, use ProcessingSwitch.crossHeads for all unpitched percussion note heads */
         if (!switches.getValue(ProcessingSwitch.crossHeads)) {
             set.remove(NOTEHEAD_CROSS);
+            set.remove(NOTEHEAD_DIAMOND_FILLED);
+            set.remove(NOTEHEAD_DIAMOND_VOID);
         }
 
         return set;

--- a/src/main/org/audiveris/omr/glyph/ShapeSet.java
+++ b/src/main/org/audiveris/omr/glyph/ShapeSet.java
@@ -849,6 +849,8 @@ public class ShapeSet
     {
         final EnumSet<Shape> set = EnumSet.of(
                 NOTEHEAD_CROSS,
+                NOTEHEAD_DIAMOND_FILLED,
+                NOTEHEAD_DIAMOND_VOID,
                 NOTEHEAD_BLACK,
                 NOTEHEAD_VOID,
                 NOTEHEAD_BLACK_SMALL,
@@ -870,6 +872,8 @@ public class ShapeSet
 
         if (!switches.getValue(ProcessingSwitch.crossHeads)) {
             set.remove(NOTEHEAD_CROSS);
+            set.remove(NOTEHEAD_DIAMOND_FILLED);
+            set.remove(NOTEHEAD_DIAMOND_VOID);
         }
 
         return set;
@@ -886,7 +890,7 @@ public class ShapeSet
      */
     public static EnumSet<Shape> getVoidTemplateNotes (Sheet sheet)
     {
-        final EnumSet<Shape> set = EnumSet.of(NOTEHEAD_VOID, WHOLE_NOTE, NOTEHEAD_VOID_SMALL);
+        final EnumSet<Shape> set = EnumSet.of(NOTEHEAD_VOID, WHOLE_NOTE, NOTEHEAD_VOID_SMALL, NOTEHEAD_DIAMOND_VOID);
 
         if (sheet == null) {
             return set;

--- a/src/main/org/audiveris/omr/image/TemplateFactory.java
+++ b/src/main/org/audiveris/omr/image/TemplateFactory.java
@@ -24,6 +24,7 @@ package org.audiveris.omr.image;
 import org.audiveris.omr.constant.Constant;
 import org.audiveris.omr.constant.ConstantSet;
 import org.audiveris.omr.glyph.Shape;
+import static org.audiveris.omr.glyph.Shape.NOTEHEAD_DIAMOND_VOID;
 import static org.audiveris.omr.glyph.Shape.NOTEHEAD_VOID;
 import static org.audiveris.omr.glyph.Shape.NOTEHEAD_VOID_SMALL;
 import static org.audiveris.omr.glyph.Shape.WHOLE_NOTE;
@@ -101,7 +102,8 @@ public class TemplateFactory
     private static final TemplateFactory INSTANCE = new TemplateFactory();
 
     /** All shapes with hole(s). */
-    private static final EnumSet shapesWithHoles = EnumSet.of(NOTEHEAD_VOID,
+    private static final EnumSet shapesWithHoles = EnumSet.of(NOTEHEAD_DIAMOND_VOID,
+                                                              NOTEHEAD_VOID,
                                                               NOTEHEAD_VOID_SMALL,
                                                               WHOLE_NOTE,
                                                               WHOLE_NOTE_SMALL);
@@ -721,6 +723,12 @@ public class TemplateFactory
     private static int getCode (Shape shape)
     {
         switch (shape) {
+        case NOTEHEAD_DIAMOND_FILLED:
+            return 226;
+
+        case NOTEHEAD_DIAMOND_VOID:
+            return 225;
+        
         case NOTEHEAD_CROSS:
             return 192;
 

--- a/src/main/org/audiveris/omr/sheet/curve/Skeleton.java
+++ b/src/main/org/audiveris/omr/sheet/curve/Skeleton.java
@@ -234,6 +234,8 @@ public class Skeleton
                         Shape.WHOLE_NOTE,
                         Shape.WHOLE_NOTE_SMALL,
                         Shape.NOTEHEAD_CROSS,
+                        Shape.NOTEHEAD_DIAMOND_FILLED,
+                        Shape.NOTEHEAD_DIAMOND_VOID,
                         Shape.NOTEHEAD_BLACK,
                         Shape.NOTEHEAD_BLACK_SMALL,
                         Shape.NOTEHEAD_VOID,

--- a/src/main/org/audiveris/omr/sheet/symbol/InterFactory.java
+++ b/src/main/org/audiveris/omr/sheet/symbol/InterFactory.java
@@ -870,6 +870,8 @@ public class InterFactory
 
         // Noteheads
         case NOTEHEAD_CROSS:
+        case NOTEHEAD_DIAMOND_FILLED:
+        case NOTEHEAD_DIAMOND_VOID:
         case NOTEHEAD_BLACK:
         case NOTEHEAD_BLACK_SMALL:
         case NOTEHEAD_VOID:

--- a/src/main/org/audiveris/omr/sig/SigReducer.java
+++ b/src/main/org/audiveris/omr/sig/SigReducer.java
@@ -407,25 +407,27 @@ public class SigReducer
                     }
 
                     // Standard beams support black heads (not void)
-                    Set<Inter> blackHeadSet = heads.get(Shape.NOTEHEAD_BLACK);
+                    for (Shape shape : new Shape[]{Shape.NOTEHEAD_BLACK, Shape.NOTEHEAD_DIAMOND_FILLED}) {
+                        Set<Inter> blackHeadSet = heads.get(shape);
 
-                    if (blackHeadSet != null) {
-                        for (Inter beam : beamSet) {
-                            BeamStemRelation bs = (BeamStemRelation) sig.getRelation(
+                        if (blackHeadSet != null) {
+                            for (Inter beam : beamSet) {
+                                BeamStemRelation bs = (BeamStemRelation) sig.getRelation(
                                     beam,
                                     stem,
                                     BeamStemRelation.class);
 
-                            for (Inter head : blackHeadSet) {
-                                if (sig.getRelation(beam, head, BeamHeadRelation.class) == null) {
-                                    // Use average of beam-stem and head-stem relation grades
-                                    HeadStemRelation hs = (HeadStemRelation) sig.getRelation(
+                                for (Inter head : blackHeadSet) {
+                                    if (sig.getRelation(beam, head, BeamHeadRelation.class) == null) {
+                                        // Use average of beam-stem and head-stem relation grades
+                                        HeadStemRelation hs = (HeadStemRelation) sig.getRelation(
                                             head,
                                             stem,
                                             HeadStemRelation.class);
-                                    double grade = (bs.getGrade() + hs.getGrade()) / 2;
+                                        double grade = (bs.getGrade() + hs.getGrade()) / 2;
 
-                                    ///sig.addEdge(beam, head, new BeamHeadRelation(grade));
+                                        ///sig.addEdge(beam, head, new BeamHeadRelation(grade));
+                                    }
                                 }
                             }
                         }

--- a/src/main/org/audiveris/omr/sig/inter/AbstractNoteInter.java
+++ b/src/main/org/audiveris/omr/sig/inter/AbstractNoteInter.java
@@ -336,6 +336,8 @@ public abstract class AbstractNoteInter
 
         map.put(Shape.QUARTER_REST, QUARTER_DURATION);
         map.put(Shape.NOTEHEAD_CROSS, QUARTER_DURATION);
+        map.put(Shape.NOTEHEAD_DIAMOND_FILLED, QUARTER_DURATION);
+        map.put(Shape.NOTEHEAD_DIAMOND_VOID, QUARTER_DURATION);
         map.put(Shape.NOTEHEAD_BLACK, QUARTER_DURATION);
         map.put(Shape.NOTEHEAD_BLACK_SMALL, QUARTER_DURATION);
 

--- a/src/main/org/audiveris/omr/ui/symbol/Symbols.java
+++ b/src/main/org/audiveris/omr/ui/symbol/Symbols.java
@@ -291,6 +291,8 @@ public abstract class Symbols
         sym.put(NON_DRAGGABLE, new NonDraggableSymbol(192));
         small(NOTEHEAD_BLACK_SMALL, 207);
         mapShape(NOTEHEAD_CROSS, 192);
+        mapShape(NOTEHEAD_DIAMOND_FILLED, 226);
+        mapShape(NOTEHEAD_DIAMOND_VOID, 225);
         mapShape(NOTEHEAD_VOID, 250);
         small(NOTEHEAD_VOID_SMALL, 250);
         //        mapShape(NO_LEGAL_TIME);


### PR DESCRIPTION
This branch drum-notation is for adding the capability of Audiveris to recognize and handle 5-line unpitched percussion (hereinafter: drum) scores. See my April 3 2022 post in Issue https://github.com/Audiveris/audiveris/issues/33#issuecomment-1086997218 for a proposed overview of steps towards this goal.

This first pull-request updates the list of Shapes to include two new noteheads, NOTEHEAD_DIAMOND_FILLED and NOTEHEAD_DIAMOND_VOID. 

The TemplateFactory can now build templates for these new heads, based on MusicalSymbols font characters 226 and 225, respectively. (For now, we just use the existing ProcessingSwitch.crossHeads to turn on or off the search for the new diamond heads. **Question**: are there users who might need to detect cross heads but not diamond heads, so a new processing switch should be created for the percussion heads other than crosses?)

The new diamond heads have been added to Symbols.java so the UI can draw them on the score. They have also been added in a couple of other classes, in an effort (still in progress!) to get them linked to nearby stems and beams.