### PR TITLE
Add .jpeg to valid image extensions

### DIFF
--- a/src/main/org/audiveris/omr/sheet/ui/BookActions.java
+++ b/src/main/org/audiveris/omr/sheet/ui/BookActions.java
@@ -2410,7 +2410,7 @@ public class BookActions
     {
 
         private final Constant.String validImageExtensions = new Constant.String(
-                ".bmp .gif .jpg .png .tiff .tif .pdf",
+                ".bmp .gif .jpg .jpeg .png .tiff .tif .pdf",
                 "Valid image file extensions, whitespace-separated");
 
         private final Constant.Boolean closeConfirmation = new Constant.Boolean(


### PR DESCRIPTION
The file browser my default should JPG files with .jpeg extension as well, as it is not uncommon to use.