### PR TITLE
WebBrowser: try xdg-open if desktop.browse fails

### DIFF
--- a/src/main/org/audiveris/omr/ui/util/WebBrowser.java
+++ b/src/main/org/audiveris/omr/ui/util/WebBrowser.java
@@ -99,6 +99,18 @@ public class WebBrowser
                 desktop.browse(uri);
             } catch (IOException ex) {
                 logger.warn("Could not launch browser " + uri, ex);
+            } catch (UnsupportedOperationException ex) {
+                logger.info("desktop.BROWSE unsupported, trying xdg-open " + uri);
+                try {
+                    Process p = Runtime.getRuntime().exec(new String[] {
+                            "xdg-open", uri.toString()
+                        });
+                    p.waitFor();
+                } catch (IOException exc) {
+                    logger.warn("Could not launch browser using xdg-open" + uri, exc);
+                } catch (InterruptedException exc) {
+                    logger.warn("Interrupted while waiting for xdg-open" + uri, exc);
+                }
             }
         } else {
             // Delegate to BareBonesBrowserLaunch-like code


### PR DESCRIPTION
Under Linux, the 'desktop.BROWSE' call fails. If this happens, replace it with an `xdg-open` call, the standard method to open URLs on the Linux desktop.