### PR TITLE
Flatpak integration with GitHub workflow

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,80 @@
+name: Build audiveris flatpak package
+
+# execute this workflow on every push
+on:
+  - push
+
+permissions:
+  contents: read
+
+jobs:
+  java-dependencies:
+    name: "Get java dependencies"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: zulu
+
+      - name: Determine Java dependencies
+        run: >-
+          dev/flatpak/create-flatpak-dependencies.py
+
+      - name: force flatpak build from ${{ github.sha }}
+        run: >-
+          sed -i
+          -e 's,\(url: https://github.com\)/.*,\1/${{ github.repository }},'
+          -e 's,tag: .*,branch: ${{ github.ref_name }},'
+          -e 's,commit: .*,commit: ${{ github.sha }},'
+          dev/flathub/org.audiveris.audiveris.yml
+
+      - name: upload flathub archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: flathub-data
+          path: dev/flathub/
+
+  flatpak:
+    name: "Flatpak"
+    runs-on: ubuntu-latest
+
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
+      options: --privileged
+
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+      fail-fast: false
+
+    steps:
+      - name: download flathub archive
+        uses: actions/download-artifact@v3
+        with:
+          name: flathub-data
+
+      - name: Install docker
+        if: ${{ matrix.arch != 'x86_64' }}
+        run: |
+          dnf -y install docker
+
+      - name: Set up QEMU
+        if: ${{ matrix.arch != 'x86_64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          build-bundle: true
+          bundle: org.audiveris.audiveris.flatpak
+          manifest-path: org.audiveris.audiveris.yml
+          cache-key: audiveris-flatpak-${{ github.sha }}
+          arch: ${{ matrix.arch }}


### PR DESCRIPTION
This PR builds on top pf #704. It adds support for aarch64 (building! - the aarch64 packages are yet untested!), and adds GitHub workflows for building flatpak packages.

The flatpak packages can be retrieved from the GitHub workflow page as artifacts, and can be [installed directly, or added to flatpak repos](https://docs.flatpak.org/en/latest/single-file-bundle).
