### PR TITLE
Update WellKnowns.java

### DIFF
--- a/src/main/org/audiveris/omr/WellKnowns.java
+++ b/src/main/org/audiveris/omr/WellKnowns.java
@@ -398,7 +398,14 @@ public abstract class WellKnowns
         final Path audiverisPath = Paths.get(appdata + TOOL_PREFIX);
 
         // User Documents
-        final String userDocs = FileSystemView.getFileSystemView().getDefaultDirectory().getPath();
+        String userDocs;
+        try {
+            userDocs = FileSystemView.getFileSystemView().getDefaultDirectory().getPath();
+        }
+        catch (Exception e) {
+            printError("Cannot open the FileSystemView, is this system running in headless mode?");
+            userDocs = "C:";
+        }
 
         switch (kind) {
         case DATA:


### PR DESCRIPTION
Removed an error when Audiverus cannot be started in batch mode on a Windows machine by system user that does not have a user interface. This change makes it possible to start Audiveris in batch mode in this scenario.

There are still some warnings appearing after this change, but the batch process runs very well.

These are the warnings:

WARNING: Cannot access 'Personal'
java.io.IOException: Could not get shell folder ID list at java.desktop/sun.awt.shell.Win32ShellFolder2.getFileSystemPath0(Native Method) at java.desktop/sun.awt.shell.Win32ShellFolder2$7.call(Win32ShellFolder2.java:666) at java.desktop/sun.awt.shell.Win32ShellFolder2$7.call(Win32ShellFolder2.java:664) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) at java.desktop/sun.awt.shell.Win32ShellFolderManager2$ComInvoker$1.run(Win32ShellFolderManager2.java:599) at java.base/java.lang.Thread.run(Thread.java:1583)

Dec 09, 2023 5:19:05 PM sun.awt.shell.Win32ShellFolderManager2 getDesktop WARNING: Cannot access 'Desktop'
java.io.IOException: Could not get shell folder ID list at java.desktop/sun.awt.shell.Win32ShellFolder2.getFileSystemPath0(Native Method) at java.desktop/sun.awt.shell.Win32ShellFolder2$7.call(Win32ShellFolder2.java:666) at java.desktop/sun.awt.shell.Win32ShellFolder2$7.call(Win32ShellFolder2.java:664) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) at java.desktop/sun.awt.shell.Win32ShellFolderManager2$ComInvoker$1.run(Win32ShellFolderManager2.java:599) at java.base/java.lang.Thread.run(Thread.java:1583)