### PR TITLE
Fixes to binarization adjust board

### DIFF
--- a/src/main/org/audiveris/omr/sheet/Picture.java
+++ b/src/main/org/audiveris/omr/sheet/Picture.java
@@ -533,6 +533,10 @@ public class Picture
                 // Try to reload image from book input path
                 SheetStub stub = sheet.getStub();
                 gray = stub.getBook().loadSheetImage(stub.getNumber());
+
+                // If file at input path no longer exists, return null
+                if (gray == null) return null;
+                
                 gray = adjustImageFormat(gray);
                 setImage(ImageKey.GRAY, gray, false);
             } catch (ImageFormatException ex) {
@@ -630,9 +634,11 @@ public class Picture
     /**
      * Report the desired source.
      * If the source is not yet cached, build the source and store it in cache via weak reference.
+     * Users are encouraged to check if the gray source exists (!= null) before using it. An .OMR
+     * file which contains an invalid path to the source file may cause the gray source to be null.
      *
      * @param key the key of desired source
-     * @return the source ready to use
+     * @return the source ready to use, or null if not available
      */
     public ByteProcessor getSource (SourceKey key)
     {


### PR DESCRIPTION
This update fixes the Binarization Adjust Board issues when opening files from .OMR.

1.) The method Picture.getGrayImage() previously would call adjustImageFormat() after trying to load the gray source. If the source was not available, it would throw an exception. I added a null check here so that this method can return null. This way, Picture.getSource(SourceKey.GRAY) will properly return null if the source is not available (which happens if an OMR is loaded which contains an invalid image file path).

2.) As a result of #1 above, the BinarizationAdjustBoard is now able to check for a gray source using Picture.getSource(SourceKey.GRAY), and if not found, it disables itself with a message to the user.

![Screenshot 2024-03-11 160704](https://github.com/Audiveris/audiveris/assets/26415062/017d36b6-a11d-4e0a-879d-588f66348e61)

3.) Also as a result of #1 above, the original BinarizationBoard no longer causes an exception when it uses Picture.getSource() to check for a gray source.

4.) The BinarizationAdjustBoard also checks to make sure the SheetView is properly loaded before calling .repaint() on the component. Not checking this caused an issue when loading an OMR file (but not when loading directly from an input image).

I also rearranged the binarizationadjustboard methods to be in alphabetical order... sorry for making it harder to read.

Herve - if you think there is anything else I should address please tell me. I was looking at some other things, but wanted to get to this quickly since I would hate to introduce a bug.