### PR TITLE
[fix] Dock icon on Mac OS X Sequoia du jour

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ application {
     mainClass.set("$project.ext.mainClass")
     
     // Needed to circumvent the limitations brought by Java 9 and above (the JigSaw cuts)
-    applicationDefaultJvmArgs = ["--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED"]
+    applicationDefaultJvmArgs = ["--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED", "--add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED"]
 }
 
 // Perhaps no longer needed?

--- a/app/src/main/java/org/audiveris/omr/ui/MacApplication.java
+++ b/app/src/main/java/org/audiveris/omr/ui/MacApplication.java
@@ -177,8 +177,8 @@ public class MacApplication
 
         try {
             //The class used to register hooks
-            Class<?> appClass = Class.forName("com.apple.eawt.Application");
-            Object app = appClass.getDeclaredConstructor().newInstance();
+            Class<?> appClass = getMacAppClass();
+            Object app = getMacAppInstance();
 
             //Enable the about menu item and the preferences menu item
             for (String methodName : new String[]
@@ -221,5 +221,31 @@ public class MacApplication
 
             return false;
         }
+    }
+
+    public static boolean setupMacMenus ()
+    {
+        if (!WellKnowns.MAC_OS_X) {
+            return false;
+        }
+    }
+
+    static Class<?> getMacAppClass ()
+        throws ClassNotFoundException
+    {
+        return Class.forName("com.apple.eawt.Application");
+    }
+
+    static private Object app;
+
+    static Object getMacAppInstance ()
+        throws NoSuchMethodException, InstantiationException,
+               ClassNotFoundException, IllegalAccessException,
+               InvocationTargetException
+    {
+        if (app == null) {
+            app = getMacAppClass().getDeclaredConstructor().newInstance();
+        }
+        return app;
     }
 }

--- a/app/src/main/java/org/audiveris/omr/ui/MacApplication.java
+++ b/app/src/main/java/org/audiveris/omr/ui/MacApplication.java
@@ -203,7 +203,26 @@ public class MacApplication
             Method addListener = appClass.getMethod("addApplicationListener", listenerClass);
             addListener.invoke(app, listenerProxy);
 
-            // display audiveris icon in the dock instead of default java one
+            return true;
+        } catch (ClassNotFoundException | IllegalAccessException | IllegalArgumentException
+                | InstantiationException | NoSuchMethodException | SecurityException
+                | InvocationTargetException ex) {
+            logger.warn("Unable to setup Mac OS X menu integration", ex);
+
+            return false;
+        }
+    }
+
+    public static boolean setupMacDockIcon ()
+    {
+        if (!WellKnowns.MAC_OS_X) {
+            return false;
+        }
+
+        try {
+            Class<?> appClass = getMacAppClass();
+            Object app = getMacAppInstance();
+
             Method getApplication = appClass.getMethod("getApplication");
             Object application = getApplication.invoke(app);
 
@@ -214,18 +233,10 @@ public class MacApplication
             setDockImage.invoke(application, icon);
 
             return true;
-        } catch (ClassNotFoundException | IllegalAccessException | IllegalArgumentException
-                | InstantiationException | NoSuchMethodException | SecurityException
-                | InvocationTargetException | MalformedURLException ex) {
-            logger.warn("Unable to setup Mac OS X GUI integration", ex);
-
-            return false;
-        }
-    }
-
-    public static boolean setupMacMenus ()
-    {
-        if (!WellKnowns.MAC_OS_X) {
+        } catch (NoSuchMethodException | InstantiationException |
+                 ClassNotFoundException | IllegalAccessException |
+                 InvocationTargetException | MalformedURLException ex) {
+            logger.warn("Unable to setup Mac OS X dock icon", ex);
             return false;
         }
     }

--- a/app/src/main/java/org/audiveris/omr/ui/MainGui.java
+++ b/app/src/main/java/org/audiveris/omr/ui/MainGui.java
@@ -290,6 +290,7 @@ public class MainGui
         // Mac Application menu
         if (WellKnowns.MAC_OS_X) {
             MacApplication.setupMacMenus();
+            MacApplication.setupMacDockIcon();
         }
     }
 


### PR DESCRIPTION
Fixes #771

- `gradlew run`: add more compatibiity bugware on the JVM command line, [as found on StackOverflow](https://stackoverflow.com/a/75920483)
- Splice `setupMacDockIcon()` (which still works) out of `setupMacMenus()` (which [doesn't](https://stackoverflow.com/questions/9239287))