### PR TITLE
Support JPEG2000 PDF image compression (fix #786)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,6 +198,7 @@ dependencies {
         [group: 'org.bytedeco', name: 'leptonica', version: "${leptVersion}-${jcppVersion}"],
         [group: 'org.bytedeco', name: 'tesseract', version: "${tessVersion}-${jcppVersion}"],
         [group: 'com.github.jai-imageio', name: 'jai-imageio-core', version: '1.4.0'],
+        [group: 'com.github.jai-imageio', name: 'jai-imageio-jpeg2000', version: '1.4.0'],
         [group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.4'],
         [group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'],
         [group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0.1'],


### PR DESCRIPTION
Simple inclusion of `jai-imageio-jpeg2000` support so that Audiveris can open PDFs with JPEG2000-compressed images (fix #786).