### PR TITLE
packaging: Add macOS x86 (legacy Intel) architecture support (see #806)

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
 
     steps:
       - name: Checkout code

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -189,6 +189,14 @@ tasks.jpackage {
             }
             type = installerType
         }
+
+        doLast {
+            def dir = layout.projectDirectory.dir(destination)
+            def defaultDmg = "${app.ext.programName}-${app.version}.dmg"
+            def archDmg = "${app.ext.programName}-${app.version}-${app.ext.hostOSArch}.dmg"
+            println "Renaming ${defaultDmg} to ${dir}/${archDmg}"
+            file("${dir}/${defaultDmg}").renameTo(file("${dir}/${archDmg}"))
+        }
     }
 
     linux {


### PR DESCRIPTION
Support legacy Mac hardware, by adding an architecture-specific suffix to `jpackage`’s `.dmg` binaries and building the additional platform format via GitHub Actions’ x86 image. Note: I don’t have an Intel Mac, so I can’t test this.