### PR TITLE
packaging: Downgrade GitHub Actions runner to macos-13 (see #807)

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        # macos-latest is for Apple Silicon (arm64) support, and
+        # macos-13 is for legacy Intel (x64) hardware support
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
It seems that GitHub requires an enterprise subscription for the `-large` runner that supports current macOS x86! Looking at https://github.com/actions/runner-images/tree/main perhaps we could try macos-13 instead of macos-latest-large?