### PR TITLE
Fix deprecation warnings for Gradle 9.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,46 +115,46 @@ repositories {
 
 dependencies {
     implementation(
-        [group: 'args4j', name: 'args4j', version: '2.33'],
-        [group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.14'],
-        [group: 'com.github.jai-imageio', name: 'jai-imageio-core', version: '1.4.0'],
-        [group: 'com.github.jai-imageio', name: 'jai-imageio-jpeg2000', version: '1.4.0'],
-        [group: 'com.itextpdf', name: 'itextpdf', version: '5.5.13.2'],
-        [group: 'com.jgoodies', name: 'jgoodies-forms', version: '1.9.0'],
-        [group: 'com.jgoodies', name: 'jgoodies-looks', version: '2.7.0'],
-        [group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0.1'],
-        [group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.1'],
-        [group: 'gov.nist.math', name: 'jama', version: '1.0.3'],
-        [group: 'javax.media', name: 'jai-core', version: '1.1.3'],
-        [group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'],
-        [group: 'net.imagej', name: 'ij', version: '1.54p'],
-        [group: 'net.jcip', name: 'jcip-annotations', version: '1.0'],
-        [group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.4'],
-        [group: 'org.apache.pdfbox', name: 'jbig2-imageio', version: '3.0.4'],
-        [group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.6'],
-        [group: 'org.apache.pdfbox', name: 'pdfbox-io', version: '3.0.6'],
-        [group: 'org.audiveris', name: 'proxymusic', version: '4.0.3'],
-        [group: 'org.bushe', name: 'eventbus', version: '1.4'],
-        [group: 'org.bytedeco', name: 'javacpp', version: jcppVersion],
-        [group: 'org.bytedeco', name: 'leptonica', version: "${leptVersion}-${jcppVersion}"],
-        [group: 'org.bytedeco', name: 'tesseract', version: "${tessVersion}-${jcppVersion}"],
-        [group: 'org.commonmark', name: 'commonmark', version: '0.27.0'],
-        [group: 'org.jdesktop.bsaf', name: 'bsaf', version: '1.9.2'],
-        [group: 'org.jfree', name: 'jfreechart', version: '1.5.6'],
-        [group: 'org.jgrapht', name: 'jgrapht-core', version: '1.5.2'],
-        [group: 'org.kohsuke', name: 'github-api', version: '1.330'],
-        [group: 'org.reflections', name: 'reflections', version: '0.10.2'],
-        [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.17']
+        'args4j:args4j:2.33',
+        'ch.qos.logback:logback-classic:1.4.14',
+        'com.github.jai-imageio:jai-imageio-core:1.4.0',
+        'com.github.jai-imageio:jai-imageio-jpeg2000:1.4.0',
+        'com.itextpdf:itextpdf:5.5.13.2',
+        'com.jgoodies:jgoodies-forms:1.9.0',
+        'com.jgoodies:jgoodies-looks:2.7.0',
+        'com.sun.xml.bind:jaxb-core:2.3.0.1',
+        'com.sun.xml.bind:jaxb-impl:2.3.1',
+        'gov.nist.math:jama:1.0.3',
+        'javax.media:jai-core:1.1.3',
+        'javax.xml.bind:jaxb-api:2.3.1',
+        'net.imagej:ij:1.54p',
+        'net.jcip:jcip-annotations:1.0',
+        'org.apache.directory.studio:org.apache.commons.io:2.4',
+        'org.apache.pdfbox:jbig2-imageio:3.0.4',
+        'org.apache.pdfbox:pdfbox:3.0.6',
+        'org.apache.pdfbox:pdfbox-io:3.0.6',
+        'org.audiveris:proxymusic:4.0.3',
+        'org.bushe:eventbus:1.4',
+        "org.bytedeco:javacpp:${jcppVersion}",
+        "org.bytedeco:leptonica:${leptVersion}-${jcppVersion}",
+        "org.bytedeco:tesseract:${tessVersion}-${jcppVersion}",
+        'org.commonmark:commonmark:0.27.0',
+        'org.jdesktop.bsaf:bsaf:1.9.2',
+        'org.jfree:jfreechart:1.5.6',
+        'org.jgrapht:jgrapht-core:1.5.2',
+        'org.kohsuke:github-api:1.330',
+        'org.reflections:reflections:0.10.2',
+        'org.slf4j:slf4j-api:2.0.17'
     )
 
     runtimeOnly(
-        [group: 'org.bytedeco', name: 'leptonica', version: "${leptVersion}-${jcppVersion}", classifier: "${app.ext.targetOS}"],
-        [group: 'org.bytedeco', name: 'tesseract', version: "${tessVersion}-${jcppVersion}", classifier: "${app.ext.targetOS}"]
+        "org.bytedeco:leptonica:${leptVersion}-${jcppVersion}:${app.ext.targetOS}",
+        "org.bytedeco:tesseract:${tessVersion}-${jcppVersion}:${app.ext.targetOS}"
     )
 
     testImplementation(
-        [group: 'junit', name: 'junit', version: '4.13.2'],
-        [group: 'org.jgrapht', name: 'jgrapht-ext', version: '1.5.2']
+        'junit:junit:4.13.2',
+        'org.jgrapht:jgrapht-ext:1.5.2'
     )
 }
 
@@ -162,8 +162,8 @@ dependencies {
 if (targetOS == "linux-x86_64") {
     dependencies {
         runtimeOnly(
-            [group: 'org.bytedeco', name: 'leptonica', version: "${leptVersion}-${jcppVersion}", classifier: "linux-arm64"],
-            [group: 'org.bytedeco', name: 'tesseract', version: "${tessVersion}-${jcppVersion}", classifier: "linux-arm64"]
+            "org.bytedeco:leptonica:${leptVersion}-${jcppVersion}:linux-arm64",
+            "org.bytedeco:tesseract:${tessVersion}-${jcppVersion}:linux-arm64"
         )
     }
 }

--- a/schemas/build.gradle
+++ b/schemas/build.gradle
@@ -104,11 +104,11 @@ repositories {
 }
 
 dependencies { 
-    implementation(group: 'args4j', name: 'args4j', version: '2.33')
-    implementation(group: 'org.codehaus.mojo', name: 'jaxb2-maven-plugin', version: '3.3.0')
-    implementation(group: 'org.apache.maven.plugin-tools', name: 'maven-plugin-annotations', version: '3.5.1')
-    implementation(group: 'org.apache.maven', name: 'maven-plugin-api', version: '3.9.11')
-    implementation(group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1')
+    implementation('args4j:args4j:2.33')
+    implementation('org.codehaus.mojo:jaxb2-maven-plugin:3.3.0')
+    implementation('org.apache.maven.plugin-tools:maven-plugin-annotations:3.5.1')
+    implementation('org.apache.maven:maven-plugin-api:3.9.11')
+    implementation('javax.xml.bind:jaxb-api:2.3.1')
 }
 
 // Main task


### PR DESCRIPTION
### Summary

This PR fixes deprecation warnings that appear when building with Gradle 9.x.

### linked issue
#890 

### Details

- Updated build configuration in:
  - `app/build.gradle`
  - `schemas/build.gradle`
- Removed deprecated usages to ensure compatibility with Gradle 9.x.

### Verification

- Project builds successfully with Gradle 9.x
- No functional changes were introduced
