### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities in the following versions:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.9.x   | :white_check_mark: |
+| 5.8.x   | :white_check_mark: |
+| < 5.8   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Audiveris, please report it by emailing the maintainers directly rather than opening a public issue.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+### What to Include
+
+When reporting a vulnerability, please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact of the vulnerability
+- Any suggested fixes (if available)
+
+### Response Timeline
+
+- You can expect an initial response within 48 hours
+- We will investigate and provide updates on the status
+- Once the vulnerability is confirmed, we will work on a fix and coordinate disclosure
+
+## Security Best Practices
+
+When using Audiveris:
+
+- Keep your installation up to date with the latest version
+- Only process score images from trusted sources
+- Be cautious when loading project files from unknown sources
+- Review the permissions requested by any plugins before installation
+
+Thank you for helping keep Audiveris and its users safe!


### PR DESCRIPTION
Addresses #859

This adds a SECURITY.md file following GitHub's recommended security policy template. It includes:
- Supported versions table
- Vulnerability reporting guidelines
- Response timeline expectations
- Security best practices for users