### PR TITLE
Fix IndexOutOfBoundsException in MetronomeInter when equalIndex is 0

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sig/inter/MetronomeInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/MetronomeInter.java
@@ -939,7 +939,7 @@ public class MetronomeInter
             ctx.noteWord = line.getWords().get(equalIndex);
             ctx.charIndex = ctx.noteWord.getValue().indexOf(noteStr);
 
-            if (ctx.charIndex == -1) {
+            if (ctx.charIndex == -1 && equalIndex > 0) {
                 // Note not found, let's look in the word before
                 ctx.noteWord = line.getWords().get(equalIndex - 1);
                 ctx.charIndex = ctx.noteWord.getValue().indexOf(noteStr);


### PR DESCRIPTION
## Summary

Fixes #812 — tempo text like "♩ = 100" causes `IndexOutOfBoundsException: Index -1` during the TEXTS step when OCR places the note symbol in a separate word before the "=" sign.

**Root cause:** `MetronomeInter.create()` at line 942 does `line.getWords().get(equalIndex - 1)` without checking that `equalIndex > 0`. When "=" is the first word (`equalIndex == 0`), it tries `get(-1)`.

**Fix:** One-line bounds check:

```java
// Before:
if (ctx.charIndex == -1) {
// After:
if (ctx.charIndex == -1 && equalIndex > 0) {
```

The existing handler at line 948 (`reporter.alert("Note characters not found...")`) already covers the "not found" case — it raises `ParsingException` which is caught at line 985. No behavioral change for the normal case where `equalIndex > 0`.

## Testing

Verified with a hymnal PDF (Amazing Grace) that previously required OCR-disabled fallback to complete:
- **Before patch:** TEXTS step crashes → no MusicXML output
- **After patch:** Completes on first attempt with OCR enabled, 141 `<lyric>` elements extracted correctly