### PR TITLE
Fix #146: Improve grouping of whole note heads into chords

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/ProcessingSwitches.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/ProcessingSwitches.java
@@ -243,7 +243,7 @@ public class ProcessingSwitches
                 "Partial whole rests");
 
         final Constant.Boolean multiWholeHeadChords = new Constant.Boolean(
-                false,
+                true,
                 "Multi-whole head chords");
 
         final Constant.Boolean chordNames = new Constant.Boolean(false, "Chord names");

--- a/app/src/main/java/org/audiveris/omr/sheet/note/ChordsBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/note/ChordsBuilder.java
@@ -27,6 +27,7 @@ import org.audiveris.omr.math.GeoUtil;
 import org.audiveris.omr.sheet.Part;
 import org.audiveris.omr.sheet.ProcessingSwitch;
 import org.audiveris.omr.sheet.ProcessingSwitches;
+import org.audiveris.omr.sheet.Scale;
 import org.audiveris.omr.sheet.Staff;
 import org.audiveris.omr.sheet.SystemInfo;
 import org.audiveris.omr.sheet.rhythm.Measure;
@@ -61,7 +62,9 @@ import org.audiveris.omr.util.Navigable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.awt.Rectangle;
 import java.awt.geom.Line2D;
+import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -350,6 +353,8 @@ public class ChordsBuilder
         final ProcessingSwitches switches = system.getSheet().getStub().getProcessingSwitches();
         final boolean multiWhole = switches.getValue(ProcessingSwitch.multiWholeHeadChords);
         final int maxDeltaPitch = constants.maxDeltaPitch.getValue();
+        final Scale scale = system.getSheet().getScale();
+        final double xTolerance = scale.getInterline().doubleValue() / 2.0;
 
         Collections.sort(wholeHeads, Inters.byCenterOrdinate);
 
@@ -378,8 +383,13 @@ public class ChordsBuilder
                         break; // Vertical gap is too large, this is the end for current chord
                     }
 
-                    // Check horizontal fit
-                    if (GeoUtil.xOverlap(chord.getBounds(), h2.getBounds()) > 0) {
+                    // Check horizontal fit: direct overlap or very close horizontally
+                    Rectangle bChord = chord.getBounds();
+                    Rectangle b2 = h2.getBounds();
+                    boolean xMatch = (GeoUtil.xOverlap(bChord, b2) > 0)
+                            || (GeoUtil.xGap(bChord, b2) < xTolerance);
+
+                    if (xMatch) {
                         chord.addMember(h2);
                         p1 = p2;
                     }
@@ -552,7 +562,7 @@ public class ChordsBuilder
     {
         private final Constant.Integer maxDeltaPitch = new Constant.Integer(
                 "pitch",
-                7,
+                12,
                 "Maximum delta pitch between two wholes in the same chord");
     }
 }


### PR DESCRIPTION
Improved grouping of whole note heads into chords by increasing vertical pitch tolerance and refining horizontal overlap detection. This addresses the issue where vertically aligned semibreves were being split into multiple chords.