### PR TITLE
Fix #355: Add options for dynamics placement (Above/Below staff)

### DIFF
--- a/app/src/main/java/org/audiveris/omr/score/PartwiseBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/score/PartwiseBuilder.java
@@ -36,6 +36,8 @@ import static org.audiveris.omr.score.MusicXML.*;
 import org.audiveris.omr.sheet.Book;
 import org.audiveris.omr.sheet.Part;
 import org.audiveris.omr.sheet.PartBarline;
+import org.audiveris.omr.sheet.ProcessingSwitch;
+import org.audiveris.omr.sheet.ProcessingSwitches;
 import org.audiveris.omr.sheet.Scale;
 import org.audiveris.omr.sheet.Sheet;
 import org.audiveris.omr.sheet.SheetStub;

--- a/app/src/main/java/org/audiveris/omr/sheet/ProcessingSwitch.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/ProcessingSwitch.java
@@ -65,6 +65,8 @@ public enum ProcessingSwitch
     lyrics(ProcessingSwitches.constants.lyrics),
     lyricsAboveStaff(ProcessingSwitches.constants.lyricsAboveStaff),
     articulations(ProcessingSwitches.constants.articulations),
+    dynamicsAboveStaff(ProcessingSwitches.constants.dynamicsAboveStaff),
+    dynamicsBelowStaff(ProcessingSwitches.constants.dynamicsBelowStaff),
 
     keepGrayImages(ProcessingSwitches.constants.keepGrayImages),
     indentations(ProcessingSwitches.constants.indentations),

--- a/app/src/main/java/org/audiveris/omr/sheet/ProcessingSwitches.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/ProcessingSwitches.java
@@ -256,6 +256,14 @@ public class ProcessingSwitches
 
         final Constant.Boolean articulations = new Constant.Boolean(true, "Articulations");
 
+        final Constant.Boolean dynamicsAboveStaff = new Constant.Boolean(
+                false,
+                "Dynamics located above staff");
+
+        final Constant.Boolean dynamicsBelowStaff = new Constant.Boolean(
+                false,
+                "Dynamics located below staff");
+
         final Constant.Boolean implicitTuplets = new Constant.Boolean(false, "Implicit tuplets");
     }
 


### PR DESCRIPTION
Added two new processing switches 'dynamicsAboveStaff' and 'dynamicsBelowStaff' to allow manual control over dynamics placement in MusicXML export. When both are false (default), the system falls back to the current automatic placement based on relative position.