### PR TITLE
Fix #621: Ensure BarlineInter is removed from StaffBarlineInter on deletion

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sig/inter/BarlineInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/BarlineInter.java
@@ -366,6 +366,12 @@ public class BarlineInter
             return;
         }
 
+        final StaffBarlineInter sb = getStaffBarline();
+
+        if (sb != null) {
+            sb.removeMember(this);
+        }
+
         if (staff != null) {
             staff.removeBarline(this);
         }


### PR DESCRIPTION
Fixed an issue where manually removed barlines would persist internally. By explicitly calling sb.removeMember(this) in BarlineInter.remove(), the deleted barline is now correctly purged from its containing StaffBarlineInter ensemble.