### PR TITLE
feat: add manual movement start toggle on systems

### DIFF
--- a/app/src/main/java/org/audiveris/omr/score/ui/EditorMenu.java
+++ b/app/src/main/java/org/audiveris/omr/score/ui/EditorMenu.java
@@ -914,10 +914,13 @@ public class EditorMenu
 
         private final MergeAction mergeAction = new MergeAction();
 
+        private final ToggleIndentAction toggleIndentAction = new ToggleIndentAction();
+
         SystemMenu ()
         {
             super("System");
             add(new JMenuItem(mergeAction));
+            add(new JMenuItem(toggleIndentAction));
         }
 
         @Override
@@ -938,6 +941,7 @@ public class EditorMenu
             }
 
             mergeAction.update();
+            toggleIndentAction.update();
         }
 
         /**
@@ -1020,6 +1024,47 @@ public class EditorMenu
                     boolean isLast = system == systems.get(systems.size() - 1);
                     boolean gridDone = sheet.getStub().getLatestStep().compareTo(OmrStep.GRID) >= 0;
                     setEnabled(!isLast && gridDone);
+                }
+            }
+        }
+
+        /**
+         * Toggle indentation (movement start) on the current system.
+         */
+        private class ToggleIndentAction
+                extends AbstractAction
+        {
+            ToggleIndentAction ()
+            {
+                putValue(SHORT_DESCRIPTION, "Toggle whether this system starts a new movement");
+            }
+
+            @Override
+            public void actionPerformed (ActionEvent e)
+            {
+                final String label = system.isIndented() ? "unmark" : "mark";
+
+                if (OMR.gui.displayConfirmation(
+                        "About to " + label + " system #" + system.getId()
+                                + " as a movement start. Do you confirm?")) {
+                    sheet.getInterController().toggleIndentation(system);
+                }
+            }
+
+            private void update ()
+            {
+                if (system == null) {
+                    setEnabled(false);
+                    putValue(NAME, "Toggle movement start");
+                } else {
+                    boolean gridDone = sheet.getStub().getLatestStep().compareTo(OmrStep.GRID) >= 0;
+                    setEnabled(gridDone);
+
+                    if (system.isIndented()) {
+                        putValue(NAME, "Unmark as movement start");
+                    } else {
+                        putValue(NAME, "Mark as movement start");
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/audiveris/omr/sheet/SystemManager.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/SystemManager.java
@@ -249,6 +249,26 @@ public class SystemManager
         return true;
     }
 
+    //--------------//
+    // rebuildPages //
+    //--------------//
+    /**
+     * Clear and rebuild pages and pageRefs based on current system indentation flags,
+     * then update the book scores accordingly.
+     * <p>
+     * This is used after a user manually toggles a system's indentation.
+     */
+    public void rebuildPages ()
+    {
+        final SheetStub stub = sheet.getStub();
+        stub.clearPageRefs();
+        sheet.clearPages();
+        allocatePages();
+        stub.getBook().updateScores(stub);
+
+        reportResults();
+    }
+
     //-------------------//
     // computeSystemArea //
     //-------------------//

--- a/app/src/main/java/org/audiveris/omr/sheet/SystemManager.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/SystemManager.java
@@ -264,6 +264,7 @@ public class SystemManager
         stub.clearPageRefs();
         sheet.clearPages();
         allocatePages();
+        stub.getBook().clearScores();
         stub.getBook().updateScores(stub);
 
         reportResults();

--- a/app/src/main/java/org/audiveris/omr/sig/ui/InterController.java
+++ b/app/src/main/java/org/audiveris/omr/sig/ui/InterController.java
@@ -1600,6 +1600,27 @@ public class InterController
         }.execute();
     }
 
+    //---------------------//
+    // toggleIndentation   //
+    //---------------------//
+    /**
+     * Toggle the indentation (movement start) flag on the provided system.
+     *
+     * @param system the system to toggle
+     */
+    @UIThread
+    public void toggleIndentation (final SystemInfo system)
+    {
+        new CtrlTask(DO, "toggleIndentation")
+        {
+            @Override
+            protected void build ()
+            {
+                seq.add(new SystemIndentTask(system));
+            }
+        }.execute();
+    }
+
     //----------------//
     // partitionHeads //
     //----------------//

--- a/app/src/main/java/org/audiveris/omr/sig/ui/SystemIndentTask.java
+++ b/app/src/main/java/org/audiveris/omr/sig/ui/SystemIndentTask.java
@@ -1,0 +1,78 @@
+//------------------------------------------------------------------------------------------------//
+//                                                                                                //
+//                                S y s t e m I n d e n t T a s k                                 //
+//                                                                                                //
+//------------------------------------------------------------------------------------------------//
+// <editor-fold defaultstate="collapsed" desc="hdr">
+//
+//  Copyright © Audiveris 2026. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the
+//  GNU Affero General Public License as published by the Free Software Foundation, either version
+//  3 of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License along with this
+//  program.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------------------------//
+// </editor-fold>
+package org.audiveris.omr.sig.ui;
+
+import org.audiveris.omr.sheet.SystemInfo;
+
+/**
+ * Class <code>SystemIndentTask</code> toggles the indentation flag on a system,
+ * which controls whether this system starts a new movement.
+ *
+ * @author Hervé Bitteur
+ */
+public class SystemIndentTask
+        extends UITask
+{
+    //~ Instance fields ----------------------------------------------------------------------------
+
+    /** The system whose indentation is toggled. */
+    private final SystemInfo system;
+
+    /** The indentation value before the toggle. */
+    private final boolean previousIndented;
+
+    //~ Constructors -------------------------------------------------------------------------------
+
+    /**
+     * Creates a new <code>SystemIndentTask</code> object.
+     *
+     * @param system the system to toggle
+     */
+    public SystemIndentTask (SystemInfo system)
+    {
+        super(system.getSig(), "toggle-indent");
+
+        this.system = system;
+        this.previousIndented = system.isIndented();
+    }
+
+    //~ Methods ------------------------------------------------------------------------------------
+
+    public SystemInfo getSystem ()
+    {
+        return system;
+    }
+
+    @Override
+    public void performDo ()
+    {
+        system.setIndented(!previousIndented);
+        sheet.getSystemManager().rebuildPages();
+    }
+
+    @Override
+    public void performUndo ()
+    {
+        system.setIndented(previousIndented);
+        sheet.getSystemManager().rebuildPages();
+    }
+}

--- a/docs/_pages/guides/ui/ui_tools/system.md
+++ b/docs/_pages/guides/ui/ui_tools/system.md
@@ -1,11 +1,16 @@
 ---
 layout: default
-title: System merge
+title: System editing
 parent: UI tools
 nav_order: 7
 ---
-# System merge
+# System editing
 {: .no_toc }
+
+- TOC
+{:toc}
+
+## System merge
 
 In the Audiveris ``GRID`` step, detected staves are gathered into systems, based on barlines found on
 the left side of the staves.
@@ -35,3 +40,26 @@ And it's done: a connector was created between the two barline portions and the 
 portions merged.
 
 We can still undo/redo the operation.
+
+## Movement start
+
+Audiveris automatically detects movement (score) boundaries by looking at system indentation —
+an indented first system signals the start of a new movement.
+This detection is controlled by the "_Use of system indentation_" processing switch in
+Book Parameters.
+
+However, in some cases (exercise books, anthologies, hymnals), multiple pieces share the same page
+without any visual indentation between them.
+In these situations, the automatic detection cannot identify the movement boundaries.
+
+You can manually mark any system as a movement start.
+Point at the desired system, and via the right-click {{ site.popup_system }} menu
+select "_Mark as movement start_".
+
+If the system is already marked as a movement start, the menu will show
+"_Unmark as movement start_" instead, allowing you to remove the boundary.
+
+After toggling, pages and scores are automatically rebuilt.
+The book export will then produce separate MusicXML files for each movement.
+
+This operation supports undo/redo.

--- a/docs/_pages/reference/updates.md
+++ b/docs/_pages/reference/updates.md
@@ -30,6 +30,9 @@ Table of contents
   - Ability to set font attributes at a sentence level to apply them to all its member words.
   - Better text word resizing, keeping a constant height/width ratio.
   - Better drag n' drop for all clefs.
+  - Ability to manually mark/unmark any system as a movement start via the System context menu,
+    for cases where automatic indentation detection cannot identify score boundaries
+    (e.g., exercise books, anthologies).
 - Engine
   - Verse numbers are detected and filtered out of the lyric lines.
   - Isolated punctuations marks (as in French) are combined with the preceding lyric syllable.

--- a/docs/_pages/tutorials/main_concepts/book_score.md
+++ b/docs/_pages/tutorials/main_concepts/book_score.md
@@ -72,12 +72,20 @@ In the vast majority of cases, there is exactly one page per sheet.
 
 The exceptions are as follows:
 1. When an _indented system_ appears anywhere in a sheet,
-  it indicates the beginning of a new movement/score.  
+  it indicates the beginning of a new movement/score.
   This sheet, as in the picture above, then contains two pages or more,
   if the indented system is not the first one in the sheet.
-2. When a sheet is _invalid_ (i.e. containing no music), it contains no page.  
+2. When a sheet is _invalid_ (i.e. containing no music), it contains no page.
   Moreover, an invalid sheet is considered as a _score break_:
    - It ends the last score in the previous valid sheet, if any.
    - The next valid sheet, if any, will start another score,
      even if it does not start with an indented system.
+
+## Manual movement boundaries
+
+In some cases (exercise books, anthologies, hymnals), multiple pieces may share the same page
+without any visual indentation between them.
+When the automatic indentation detection cannot identify these boundaries, you can manually
+mark any system as a movement start via the right-click
+[System context menu](../../guides/ui/ui_tools/system.md#movement-start).
 


### PR DESCRIPTION
Adds a right-click menu action on systems to manually mark/unmark a system as a movement start, independent of automatic indentation detection. This is useful for exercise books and anthologies where multiple pieces share a page without visual indentation.

Changes:
- New SystemIndentTask for undo/redo support
- New toggleIndentation method in InterController
- New rebuildPages method in SystemManager
- "Mark/Unmark as movement start" action in System context menu


### After
Being able to separate scores manually and not only with indentations
<img width="370" height="109" alt="image" src="https://github.com/user-attachments/assets/6497676e-ccf1-404b-9ebf-af4270a1b66c" />

Tested locally
- [x] toggled several systems as new movment and rebuilt scores -> allowed extra exports
- [x] toggled several systems as not movments and rebuilt scores -> returned to original state

This code was written mainly by claude, 
I wanted this for something and thought it might come handy as a good feature