### PR TITLE
Add configurable keyboard shortcuts for shape assignments

### DIFF
--- a/app/res/shape-shortcuts.xml
+++ b/app/res/shape-shortcuts.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    Default keyboard shortcuts for shape assignments.
+
+    Each <set> defines a shape family selected by its 'key' character.
+    Each <shape> within a set defines a specific shape selected by its 'key' character.
+    The full shortcut is the set key followed by the shape key (e.g., "af" for FLAT).
+
+    To customize, copy this file to your Audiveris config folder and edit as desired.
+-->
+<shape-shortcuts>
+
+    <set name="Accidentals" key="a">
+        <shape name="FLAT" key="f"/>
+        <shape name="NATURAL" key="n"/>
+        <shape name="SHARP" key="s"/>
+    </set>
+
+    <set name="BeamsEtc" key="b">
+        <shape name="BEAM" key="f"/>
+        <shape name="BEAM_HOOK" key="h"/>
+        <shape name="TUPLET_THREE" key="3"/>
+    </set>
+
+    <set name="Dynamics" key="d">
+        <shape name="DYNAMICS_P" key="p"/>
+        <shape name="DYNAMICS_MF" key="m"/>
+        <shape name="DYNAMICS_F" key="f"/>
+    </set>
+
+    <set name="Flags" key="f">
+        <shape name="FLAG_1" key="u"/>
+        <shape name="FLAG_1_DOWN" key="d"/>
+    </set>
+
+    <set name="HeadsAndDot" key="h">
+        <shape name="WHOLE_NOTE" key="w"/>
+        <shape name="NOTEHEAD_VOID" key="v"/>
+        <shape name="NOTEHEAD_BLACK" key="b"/>
+        <shape name="AUGMENTATION_DOT" key="d"/>
+        <shape name="HALF_NOTE_UP" key="h"/>
+        <shape name="QUARTER_NOTE_UP" key="q"/>
+    </set>
+
+    <set name="Rests" key="r">
+        <shape name="WHOLE_REST" key="1"/>
+        <shape name="HALF_REST" key="2"/>
+        <shape name="QUARTER_REST" key="4"/>
+        <shape name="EIGHTH_REST" key="8"/>
+    </set>
+
+    <set name="Texts" key="t">
+        <shape name="LYRICS" key="l"/>
+        <shape name="TEXT" key="t"/>
+        <shape name="METRONOME" key="m"/>
+    </set>
+
+    <set name="Physicals" key="p">
+        <shape name="SLUR_ABOVE" key="a"/>
+        <shape name="SLUR_BELOW" key="b"/>
+        <shape name="STEM" key="s"/>
+    </set>
+
+</shape-shortcuts>

--- a/app/src/main/java/org/audiveris/omr/sig/ui/ShapeBoard.java
+++ b/app/src/main/java/org/audiveris/omr/sig/ui/ShapeBoard.java
@@ -86,7 +86,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+
 import java.util.stream.Collectors;
 
 import javax.swing.JButton;
@@ -135,21 +135,8 @@ public class ShapeBoard
     /** Unicode value for black up-pointing triangle sign: {@value}. */
     private static final String BACK = "\u25B2";
 
-    /** Map first typed char to selected shape set. */
-    private static final Map<Character, ShapeSet> setMap = new HashMap<>();
-
-    /** Reverse of setMap. */
-    private static final Map<ShapeSet, Character> reverseSetMap = new HashMap<>();
-
-    /** Map 2-char typed string to selected shape. */
-    private static final Map<String, Shape> shapeMap = new HashMap<>();
-
-    /** Reverse of shapeMap. */
-    private static final Map<Shape, String> reverseShapeMap = new HashMap<>();
-
     static {
-        populateCharMaps();
-        populateReverseCharMaps();
+        ShapeShortcuts.loadAllConfigurations();
     }
 
     //~ Instance fields ----------------------------------------------------------------------------
@@ -359,7 +346,7 @@ public class ShapeBoard
                     button.addActionListener(setListener);
                     button.setBorderPainted(false);
 
-                    final Character shortcut = reverseSetMap.get(set);
+                    final Character shortcut = ShapeShortcuts.getReverseSetMap().get(set);
                     button.setToolTipText(set.getName() + standardized(shortcut));
                     panel.add(button);
 
@@ -459,7 +446,7 @@ public class ShapeBoard
         closeSet();
 
         // First character (set)
-        ShapeSet set = setMap.get(c);
+        ShapeSet set = ShapeShortcuts.getSetMap().get(c);
 
         if (set == null) {
             return false;
@@ -687,7 +674,7 @@ public class ShapeBoard
     public void processString (String str)
     {
         if (isSelected()) {
-            final Shape shape = shapeMap.get(str);
+            final Shape shape = ShapeShortcuts.getShapeMap().get(str);
             logger.debug("shape:{}", shape);
 
             if (shape != null) {
@@ -860,72 +847,6 @@ public class ShapeBoard
 
     //~ Static Methods -----------------------------------------------------------------------------
 
-    //------------------//
-    // populateCharMaps //
-    //------------------//
-    private static void populateCharMaps ()
-    {
-        char c;
-
-        setMap.put(c = 'a', ShapeSet.Accidentals);
-        shapeMap.put("" + c + 'f', Shape.FLAT);
-        shapeMap.put("" + c + 'n', Shape.NATURAL);
-        shapeMap.put("" + c + 's', Shape.SHARP);
-
-        setMap.put(c = 'b', ShapeSet.BeamsEtc);
-        shapeMap.put("" + c + 'f', Shape.BEAM);
-        shapeMap.put("" + c + 'h', Shape.BEAM_HOOK);
-        shapeMap.put("" + c + '3', Shape.TUPLET_THREE);
-
-        setMap.put(c = 'd', ShapeSet.Dynamics);
-        shapeMap.put("" + c + 'p', Shape.DYNAMICS_P);
-        shapeMap.put("" + c + 'm', Shape.DYNAMICS_MF);
-        shapeMap.put("" + c + 'f', Shape.DYNAMICS_F);
-
-        setMap.put(c = 'f', ShapeSet.Flags);
-        shapeMap.put("" + c + 'u', Shape.FLAG_1);
-        shapeMap.put("" + c + 'd', Shape.FLAG_1_DOWN);
-
-        setMap.put(c = 'h', ShapeSet.HeadsAndDot);
-        shapeMap.put("" + c + 'w', Shape.WHOLE_NOTE);
-        shapeMap.put("" + c + 'v', Shape.NOTEHEAD_VOID);
-        shapeMap.put("" + c + 'b', Shape.NOTEHEAD_BLACK);
-        shapeMap.put("" + c + 'd', Shape.AUGMENTATION_DOT);
-        shapeMap.put("" + c + 'h', Shape.HALF_NOTE_UP);
-        shapeMap.put("" + c + 'q', Shape.QUARTER_NOTE_UP);
-
-        setMap.put(c = 'r', ShapeSet.Rests);
-        shapeMap.put("" + c + '1', Shape.WHOLE_REST);
-        shapeMap.put("" + c + '2', Shape.HALF_REST);
-        shapeMap.put("" + c + '4', Shape.QUARTER_REST);
-        shapeMap.put("" + c + '8', Shape.EIGHTH_REST);
-
-        setMap.put(c = 't', ShapeSet.Texts);
-        shapeMap.put("" + c + 'l', Shape.LYRICS);
-        shapeMap.put("" + c + 't', Shape.TEXT);
-        shapeMap.put("" + c + 'm', Shape.METRONOME);
-
-        setMap.put(c = 'p', ShapeSet.Physicals);
-        shapeMap.put("" + c + 'a', Shape.SLUR_ABOVE);
-        shapeMap.put("" + c + 'b', Shape.SLUR_BELOW);
-        shapeMap.put("" + c + 's', Shape.STEM);
-    }
-
-    //-------------------------//
-    // populateReverseCharMaps //
-    //-------------------------//
-    private static void populateReverseCharMaps ()
-    {
-        // Build reverse of setMap
-        for (Entry<Character, ShapeSet> entry : setMap.entrySet()) {
-            reverseSetMap.put(entry.getValue(), entry.getKey());
-        }
-
-        // Build reverse of shapeMap
-        for (Entry<String, Shape> entry : shapeMap.entrySet()) {
-            reverseShapeMap.put(entry.getValue(), entry.getKey());
-        }
-    }
 
     //--------------//
     // standardized //
@@ -1445,7 +1366,7 @@ public class ShapeBoard
             setIcon(decoSymbol.getTinyVersion());
             setName(decoSymbol.getShape().toString());
 
-            final String shortcut = reverseShapeMap.get(decoSymbol.getShape());
+            final String shortcut = ShapeShortcuts.getReverseShapeMap().get(decoSymbol.getShape());
             setToolTipText(decoSymbol.getTip() + standardized(shortcut));
 
             setBorderPainted(true);

--- a/app/src/main/java/org/audiveris/omr/sig/ui/ShapeShortcuts.java
+++ b/app/src/main/java/org/audiveris/omr/sig/ui/ShapeShortcuts.java
@@ -1,0 +1,370 @@
+//------------------------------------------------------------------------------------------------//
+//                                                                                                //
+//                                  S h a p e S h o r t c u t s                                   //
+//                                                                                                //
+//------------------------------------------------------------------------------------------------//
+// <editor-fold defaultstate="collapsed" desc="hdr">
+//
+//  Copyright © Audiveris 2026. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the
+//  GNU Affero General Public License as published by the Free Software Foundation, either version
+//  3 of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License along with this
+//  program.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------------------------//
+// </editor-fold>
+package org.audiveris.omr.sig.ui;
+
+import org.audiveris.omr.WellKnowns;
+import org.audiveris.omr.glyph.Shape;
+import org.audiveris.omr.glyph.ShapeSet;
+import org.audiveris.omr.util.Jaxb;
+import static org.audiveris.omr.util.UriUtil.toURI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.stream.XMLStreamException;
+
+/**
+ * Class <code>ShapeShortcuts</code> manages keyboard shortcuts for shape assignments.
+ * <p>
+ * Shortcuts are 2-character sequences: the first character selects a shape set (family),
+ * the second character selects a specific shape within that set.
+ * <p>
+ * Default shortcuts are loaded from system resource {@code shape-shortcuts.xml}.
+ * User can override them by placing a custom {@code shape-shortcuts.xml} in the config folder.
+ *
+ * @author Audiveris
+ */
+public abstract class ShapeShortcuts
+{
+    //~ Static fields/initializers -----------------------------------------------------------------
+
+    private static final Logger logger = LoggerFactory.getLogger(ShapeShortcuts.class);
+
+    /** Name of the configuration file. */
+    private static final String FILE_NAME = "shape-shortcuts.xml";
+
+    /** JAXB context for unmarshalling/marshalling. */
+    private static volatile JAXBContext jaxbContext;
+
+    /** Map first typed char to selected shape set. */
+    private static final Map<Character, ShapeSet> setMap = new HashMap<>();
+
+    /** Reverse of setMap. */
+    private static final Map<ShapeSet, Character> reverseSetMap = new HashMap<>();
+
+    /** Map 2-char typed string to selected shape. */
+    private static final Map<String, Shape> shapeMap = new HashMap<>();
+
+    /** Reverse of shapeMap. */
+    private static final Map<Shape, String> reverseShapeMap = new HashMap<>();
+
+    //~ Constructors -------------------------------------------------------------------------------
+
+    /** Not meant to be instantiated. */
+    private ShapeShortcuts ()
+    {
+    }
+
+    //~ Static Methods -----------------------------------------------------------------------------
+
+    //--------//
+    // getJaxbContext //
+    //--------//
+    private static JAXBContext getJaxbContext ()
+            throws JAXBException
+    {
+        // Local copy to avoid race
+        JAXBContext ctx = jaxbContext;
+
+        if (ctx == null) {
+            synchronized (ShapeShortcuts.class) {
+                ctx = jaxbContext;
+
+                if (ctx == null) {
+                    jaxbContext = ctx = JAXBContext.newInstance(ShortcutList.class);
+                }
+            }
+        }
+
+        return ctx;
+    }
+
+    //---------//
+    // getSetMap //
+    //---------//
+    /**
+     * Report the map from initial character to shape set.
+     *
+     * @return the setMap
+     */
+    public static Map<Character, ShapeSet> getSetMap ()
+    {
+        return setMap;
+    }
+
+    //---------//
+    // getReverseSetMap //
+    //---------//
+    /**
+     * Report the reverse map from shape set to initial character.
+     *
+     * @return the reverseSetMap
+     */
+    public static Map<ShapeSet, Character> getReverseSetMap ()
+    {
+        return reverseSetMap;
+    }
+
+    //---------//
+    // getShapeMap //
+    //---------//
+    /**
+     * Report the map from 2-char string to shape.
+     *
+     * @return the shapeMap
+     */
+    public static Map<String, Shape> getShapeMap ()
+    {
+        return shapeMap;
+    }
+
+    //---------//
+    // getReverseShapeMap //
+    //---------//
+    /**
+     * Report the reverse map from shape to 2-char string.
+     *
+     * @return the reverseShapeMap
+     */
+    public static Map<Shape, String> getReverseShapeMap ()
+    {
+        return reverseShapeMap;
+    }
+
+    //------------------------//
+    // loadAllConfigurations //
+    //------------------------//
+    /**
+     * Load shortcuts from system resource, then optionally override with user config.
+     */
+    public static void loadAllConfigurations ()
+    {
+        // System configuration (mandatory)
+        final URI systemUri = toURI(WellKnowns.RES_URI, FILE_NAME);
+
+        // User configuration (optional override)
+        final Path userPath = WellKnowns.CONFIG_FOLDER.resolve(FILE_NAME);
+
+        // Load system defaults first
+        try {
+            loadConfiguration(systemUri);
+            logger.debug("Loaded system shape shortcuts from {}", systemUri);
+        } catch (Exception ex) {
+            logger.error("Failed to load system shape shortcuts from {}", systemUri, ex);
+        }
+
+        // Then load user overrides if present
+        if (Files.exists(userPath)) {
+            try {
+                loadConfiguration(userPath.toUri());
+                logger.info("Loaded user shape shortcuts from {}", userPath);
+            } catch (Exception ex) {
+                logger.warn("Failed to load user shape shortcuts from {}", userPath, ex);
+            }
+        }
+
+        // Build reverse maps
+        buildReverseMaps();
+    }
+
+    //---------//
+    // loadConfiguration //
+    //---------//
+    private static void loadConfiguration (URI uri)
+            throws IOException, JAXBException
+    {
+        try (InputStream is = uri.toURL().openStream()) {
+            final ShortcutList list = (ShortcutList) Jaxb.unmarshal(is, getJaxbContext());
+
+            if (list != null && list.sets != null) {
+                for (SetEntry setEntry : list.sets) {
+                    final ShapeSet shapeSet = ShapeSet.getShapeSet(setEntry.name);
+
+                    if (shapeSet == null) {
+                        logger.warn("Unknown shape set: {}", setEntry.name);
+                        continue;
+                    }
+
+                    final char setChar = setEntry.key.charAt(0);
+                    setMap.put(setChar, shapeSet);
+
+                    if (setEntry.shapes != null) {
+                        for (ShapeEntry shapeEntry : setEntry.shapes) {
+                            try {
+                                final Shape shape = Shape.valueOf(shapeEntry.name);
+                                final String twoChar = "" + setChar + shapeEntry.key.charAt(0);
+                                shapeMap.put(twoChar, shape);
+                            } catch (IllegalArgumentException ex) {
+                                logger.warn("Unknown shape: {}", shapeEntry.name);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    //------------------//
+    // buildReverseMaps //
+    //------------------//
+    private static void buildReverseMaps ()
+    {
+        reverseSetMap.clear();
+
+        for (Entry<Character, ShapeSet> entry : setMap.entrySet()) {
+            reverseSetMap.put(entry.getValue(), entry.getKey());
+        }
+
+        reverseShapeMap.clear();
+
+        for (Entry<String, Shape> entry : shapeMap.entrySet()) {
+            reverseShapeMap.put(entry.getValue(), entry.getKey());
+        }
+    }
+
+    //---------------------//
+    // saveUserShortcuts //
+    //---------------------//
+    /**
+     * Save the current shortcut configuration to user config folder.
+     */
+    public static void saveUserShortcuts ()
+    {
+        final Path userPath = WellKnowns.CONFIG_FOLDER.resolve(FILE_NAME);
+
+        try {
+            final ShortcutList list = buildShortcutList();
+            Jaxb.marshal(list, userPath, getJaxbContext());
+            logger.info("Saved user shape shortcuts to {}", userPath);
+        } catch (IOException | JAXBException | XMLStreamException ex) {
+            logger.warn("Failed to save user shape shortcuts to {}", userPath, ex);
+        }
+    }
+
+    //--------------------//
+    // buildShortcutList //
+    //--------------------//
+    private static ShortcutList buildShortcutList ()
+    {
+        final ShortcutList list = new ShortcutList();
+        list.sets = new ArrayList<>();
+
+        for (Entry<Character, ShapeSet> setEntry : setMap.entrySet()) {
+            final char setChar = setEntry.getKey();
+            final ShapeSet shapeSet = setEntry.getValue();
+            final SetEntry se = new SetEntry();
+            se.name = shapeSet.getName();
+            se.key = String.valueOf(setChar);
+            se.shapes = new ArrayList<>();
+
+            // Collect all shapes that belong to this set
+            for (Entry<String, Shape> shapeEntry : shapeMap.entrySet()) {
+                final String twoChar = shapeEntry.getKey();
+
+                if (twoChar.charAt(0) == setChar) {
+                    final ShapeEntry she = new ShapeEntry();
+                    she.name = shapeEntry.getValue().name();
+                    she.key = String.valueOf(twoChar.charAt(1));
+                    se.shapes.add(she);
+                }
+            }
+
+            list.sets.add(se);
+        }
+
+        return list;
+    }
+
+    //~ Inner Classes ------------------------------------------------------------------------------
+
+    //--------------//
+    // ShortcutList //
+    //--------------//
+    /**
+     * Root element for the shape-shortcuts XML file.
+     */
+    @XmlAccessorType(XmlAccessType.NONE)
+    @XmlRootElement(name = "shape-shortcuts")
+    public static class ShortcutList
+    {
+        @XmlElement(name = "set")
+        List<SetEntry> sets;
+    }
+
+    //----------//
+    // SetEntry //
+    //----------//
+    /**
+     * A shape set with its shortcut key and contained shape entries.
+     */
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class SetEntry
+    {
+        /** Name of the ShapeSet (e.g., "Accidentals"). */
+        @XmlAttribute(name = "name")
+        String name;
+
+        /** Single-char key to select this set. */
+        @XmlAttribute(name = "key")
+        String key;
+
+        /** Shape entries within this set. */
+        @XmlElement(name = "shape")
+        List<ShapeEntry> shapes;
+    }
+
+    //------------//
+    // ShapeEntry //
+    //------------//
+    /**
+     * A single shape with its shortcut key.
+     */
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class ShapeEntry
+    {
+        /** Name of the Shape enum constant (e.g., "FLAT"). */
+        @XmlAttribute(name = "name")
+        String name;
+
+        /** Single-char key to select this shape within its set. */
+        @XmlAttribute(name = "key")
+        String key;
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted hardcoded shape keyboard shortcuts from `ShapeBoard.java` into a new `ShapeShortcuts` class that loads mappings from XML configuration
- Added `shape-shortcuts.xml` default resource file with all existing shortcut mappings
- Users can now customize shortcuts by placing a `shape-shortcuts.xml` in their Audiveris config folder, which overrides system defaults (following the same pattern as `drum-set.xml`)

## Test plan
- [ ] Verify the application compiles and starts without errors
- [ ] Verify existing 2-char keyboard shortcuts still work (e.g., `hb` for NOTEHEAD_BLACK, `af` for FLAT)
- [ ] Verify tooltips on shape buttons still show shortcut hints
- [ ] Place a custom `shape-shortcuts.xml` in the config folder with modified mappings and verify they take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)