### PR TITLE
Fix flatpak workflow for release event

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -124,7 +124,9 @@ jobs:
           gh repo clone https://github.com/flathub/org.audiveris.audiveris \
             flathub
           cd flathub
-          git switch -c "$BASE" "origin/$BASE"
+          if [[ "$BASE" != master ]]; then
+              git switch -c "$BASE" "origin/$BASE"
+          fi
           git remote -v
           git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/flathub/org.audiveris.audiveris
           git remote -v

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -84,6 +84,7 @@ jobs:
     needs: java-dependencies
     env:
       GH_TOKEN: ${{ secrets.FLATHUB_TOKEN }}
+      BASE_BRANCH: ${{ secrets.BASE_BRANCH }}
 
     steps:
       - name: Download flathub content
@@ -102,7 +103,9 @@ jobs:
           git config --global user.email 'flatpak-pr@audiveris.org'
 
           # Which flathub branch to create PR for
-          if [[ "${{ github.event_name }}" = release ]]; then
+          if [[ "$BASE_BRANCH" ]]; then
+            BASE=$BASE_BRANCH
+          elif [[ "${{ github.event_name }}" = release ]]; then
             BASE=master
           else
             BASE=beta


### PR DESCRIPTION
The flatpak workflow would error out if the base branch was set to "master", which broke the workflow for releases. Fix it. Also, allow the repository owner to override the automatic choice of the target branch by setting the BASE_BRANCH repository secret (mainly for testing).
