### PR TITLE
RFC: Fix for issue #896: Enable HiDPI scaling on Linux Wayland

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -145,7 +145,8 @@ dependencies {
         'org.jgrapht:jgrapht-core:1.5.2',
         'org.kohsuke:github-api:1.330',
         'org.reflections:reflections:0.10.2',
-        'org.slf4j:slf4j-api:2.0.17'
+        'org.slf4j:slf4j-api:2.0.17',
+        'net.java.dev.jna:jna:5.14.0'
     )
 
     runtimeOnly(
@@ -220,8 +221,11 @@ application {
     // WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
     // WARNING: Restricted methods will be blocked in a future release unless native access is enabled
     //
+    // Arg 3: Enable HiDPI/display scaling support for Linux Wayland (GNOME, KDE)
+    //
     applicationDefaultJvmArgs = ["--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED",
-                                 "--enable-native-access=ALL-UNNAMED"]
+                                 "--enable-native-access=ALL-UNNAMED",
+                                 "-Dsun.java2d.uiScale.enabled=true"]
 }
 
 // Perhaps no longer needed?

--- a/app/src/main/java/org/audiveris/omr/WellKnowns.java
+++ b/app/src/main/java/org/audiveris/omr/WellKnowns.java
@@ -206,6 +206,11 @@ public abstract class WellKnowns
         disableMediaLib();
     }
 
+    static {
+        /** Enable HiDPI scaling support on Linux Wayland. */
+        enableHiDpiScaling();
+    }
+
     //~ Constructors -------------------------------------------------------------------------------
 
     /** Not meant to be instantiated. */
@@ -265,6 +270,82 @@ public abstract class WellKnowns
             System.setProperty(KEY, "true");
         }
     }
+
+    //--------------------//
+    // enableHiDpiScaling //
+    //--------------------//
+    private static void enableHiDpiScaling ()
+    {
+        if (!LINUX || System.getProperty("sun.java2d.uiScale") != null) {
+            return;
+        }
+
+        // Manual override via GDK_SCALE
+        String gdkScale = System.getenv("GDK_SCALE");
+        if (gdkScale != null && !gdkScale.isEmpty()) {
+            try {
+                System.setProperty("sun.java2d.uiScale", gdkScale);
+                return;
+            } catch (Exception ignored) {
+            }
+        }
+
+        // Auto-detect monitor scaling via GDK
+        try {
+            int scale = getGdkMaxScale();
+            if (scale > 1) {
+                System.setProperty("sun.java2d.uiScale", String.valueOf(scale));
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    //------------------//
+    // getGdkMaxScale   //
+    //------------------//
+    private static int getGdkMaxScale ()
+    {
+        try {
+            // Load GTK library via JNA
+            com.sun.jna.Native.register("gtk-3");
+
+            // Initialize GTK (required before any GTK/GDK calls)
+            if (!gtk_init_check(null, null)) {
+                return 0;
+            }
+
+            // Get default display
+            com.sun.jna.Pointer display = gdk_display_get_default();
+            if (display == null) {
+                return 0;
+            }
+
+            // Get number of monitors and find maximum scale
+            int nMonitors = gdk_display_get_n_monitors(display);
+            int maxScale = 0;
+
+            for (int i = 0; i < nMonitors; i++) {
+                com.sun.jna.Pointer monitor = gdk_display_get_monitor(display, i);
+                if (monitor != null) {
+                    int scale = gdk_monitor_get_scale_factor(monitor);
+                    if (scale > maxScale) {
+                        maxScale = scale;
+                    }
+                }
+            }
+
+            return maxScale;
+        } catch (Exception ex) {
+            return 0;
+        }
+    }
+
+    // GTK/GDK native function declarations
+    private static native boolean gtk_init_check(com.sun.jna.ptr.IntByReference argc, com.sun.jna.ptr.PointerByReference argv);
+    private static native com.sun.jna.Pointer gdk_display_get_default();
+    private static native int gdk_display_get_n_monitors(com.sun.jna.Pointer display);
+    private static native com.sun.jna.Pointer gdk_display_get_monitor(com.sun.jna.Pointer display, int num);
+    private static native int gdk_monitor_get_scale_factor(com.sun.jna.Pointer monitor);
 
     //--------------//
     // ensureLoaded //

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -201,6 +201,7 @@ tasks.jpackage {
     // REMINDER: Check consistency with "applicationDefaultJvmArgs" in file app/build.gradle
     javaOptions         = ["--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED",
                            "--enable-native-access=ALL-UNNAMED",
+                           "-Dsun.java2d.uiScale.enabled=true",
                            "-Dfile.encoding=UTF-8",
                            "-Xms512m",
                            "-Xmx8G"]


### PR DESCRIPTION
## TENTATIVE fix for the HiDPI scaling problems

@hbitteur: I created this PR with the help of an AI (Claude). 

It took a pretty large number of iterations to get it right, but now it works even on multi-monitor systems. 

* For Wayland fractional scaling (e.g. 125%), the application needs to scale to the next-highest integer ratio (`ceil()`, here 200%). The compositor will then scale down to achieve the desired UI size.
* In multi-monitor setups, the application needs to scale to the largest factor used on any active monitor, again using the `ceil`.

~The code fetches the current display configuration from DBus and parses the output to obtain the current monitor scaling factor. I am not convinced that this is the simplest / most elegant solution possible. Still looking for something better, and with less code.~

The commit description from the AI follows.

----
   Fix for issue #896: Enable HiDPI scaling on Linux Wayland
    
    Fonts and icons were appearing tiny when GNOME/KDE display scaling was
    set to >100%. This fix detects monitor scaling using GTK/GDK's native API.
    
    Implementation:
    - Uses JNA to call GTK/GDK library functions directly
    - Initializes GTK with gtk_init_check()
    - Queries gdk_monitor_get_scale_factor() for all monitors
    - Uses the maximum scale across monitors
    - GDK automatically returns the ceiling for fractional scaling
      (e.g., 1.25x GNOME setting -> GDK returns 2)
    
    This uses the proper GTK/GDK API that the desktop environment provides,
    which is much cleaner than D-Bus calls or text parsing.
    
    Changes:
    - app/build.gradle: Added JNA dependency and -Dsun.java2d.uiScale.enabled=true
    - packaging/build.gradle: Added -Dsun.java2d.uiScale.enabled=true
    - WellKnowns.java: Added enableHiDpiScaling() using GTK/GDK API
    
    Manual override: Set GDK_SCALE=2 or -Dsun.java2d.uiScale=2
    
  