### PR TITLE
Fix #893: NPE in KeyInter for percussion/unknown clefs

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sig/inter/KeyInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/KeyInter.java
@@ -1177,6 +1177,15 @@ public class KeyInter
 
         final ClefKind clefKind = clef.getKind();
 
+        // A key signature is meaningful only for a pitched clef of a known kind.
+        // Percussion clefs (and any clef with no usable kind) carry no key signature and are
+        // absent from the pitches maps. Bail out cleanly here rather than later dereferencing
+        // a null pitches array (see issue #893).
+        if (!SHARP_PITCHES_MAP.containsKey(clefKind)) {
+            logger.debug("No key signature applicable for clef {} before {}", clef, firstAlter);
+            return null;
+        }
+
         Integer cancelFifths = null; // Used only for a cancel key
 
         // Determine target pitches to check vertical position


### PR DESCRIPTION
## Summary
Fixes #893. Transcribing a score whose system contains a **percussion staff** can abort the `LINKS` step with:
```
NullPointerException: Cannot load from int array because "pitches" is null
  at org.audiveris.omr.sig.inter.KeyInter.checkConfiguration(KeyInter.java)
  at org.audiveris.omr.sig.inter.KeyInter.lookupCandidates(KeyInter.java)
  at org.audiveris.omr.sheet.symbol.SymbolsLinker.process(SymbolsLinker.java)
```
This prevents any export (the reporter's orchestral "Partitur" has percussion staves).

## Root cause
`checkConfiguration` guards against a null effective clef, but then calls `getPitches(clefKind, shape)`, which does `map.get(clefKind)` on `SHARP_PITCHES_MAP` / `FLAT_PITCHES_MAP`. Those `EnumMap`s only contain the seven **pitched** `ClefKind`s — there is no entry for `ClefKind.PERCUSSION` (nor for a `null` kind). So when the effective clef before an accidental is a percussion clef, `getPitches` returns `null` and the subsequent `pitches[j]` access throws.

## Fix
A key signature is only meaningful for a pitched clef, so bail out cleanly when the clef kind is absent from the pitches maps — mirroring the existing `clef == null` guard a few lines above. Returning `null` (i.e. "no key configuration here") is already an expected, handled outcome for this method.

```java
if (!SHARP_PITCHES_MAP.containsKey(clefKind)) {
    logger.debug("No key signature applicable for clef {} before {}", clef, firstAlter);
    return null;
}
```

## Testing
`build` + the full unit-test suite pass on JDK 25 (GitHub Actions). I was not able to add a regression test or reproduce against the original score (the report's score isn't public and `checkConfiguration` is private with heavy fixtures), so the behavioural fix rests on the root-cause analysis above — a maintainer with a percussion-containing score can confirm the crash no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
