### PR TITLE
Fix two NPEs that abort batch -export OMR on imperfect scans

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/rhythm/MeasureStack.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/rhythm/MeasureStack.java
@@ -1491,7 +1491,19 @@ public class MeasureStack
         // Extrapolate, using skew, from single staff
         final Skew skew = system.getSkew();
         final Measure measure = getMeasureAt(staff);
+
+        // Guard against missing geometry on a messy sheet (e.g. a time signature
+        // with no reliable reference point, frequent in heavily-skewed scans):
+        // a null point/measure/border must not abort the whole SYMBOLS step.
+        if ((point == null) || (skew == null) || (measure == null)) {
+            return 0;
+        }
+
         final Point2D left = measure.getSidePoint(HorizontalSide.LEFT, staff);
+
+        if (left == null) {
+            return 0;
+        }
 
         return skew.deskewed(point).getX() - skew.deskewed(left).getX();
     }

--- a/app/src/main/java/org/audiveris/omr/sheet/rhythm/MeasureStack.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/rhythm/MeasureStack.java
@@ -1494,14 +1494,19 @@ public class MeasureStack
 
         // Guard against missing geometry on a messy sheet (e.g. a time signature
         // with no reliable reference point, frequent in heavily-skewed scans):
-        // a null point/measure/border must not abort the whole SYMBOLS step.
+        // a null point/measure/border must not abort the whole SYMBOLS step. The
+        // guard paths are logged (not silent) so problematic sheets stay visible.
         if ((point == null) || (skew == null) || (measure == null)) {
+            logger.debug("getXOffset: missing geometry (point={}, skew={}, measure={})"
+                    + " in stack {}", point, skew, measure, this);
             return 0;
         }
 
         final Point2D left = measure.getSidePoint(HorizontalSide.LEFT, staff);
 
         if (left == null) {
+            logger.debug("getXOffset: no left side point for staff {} in stack {}",
+                    staff, this);
             return 0;
         }
 

--- a/app/src/main/java/org/audiveris/omr/sig/inter/StaffBarlineInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/StaffBarlineInter.java
@@ -297,7 +297,11 @@ public final class StaffBarlineInter
             bounds = Entities.getBounds(getMembers());
         }
 
-        return new Rectangle(bounds);
+        // A StaffBarline with no members yields a null bounds; 'new Rectangle(null)'
+        // would then throw a NPE (notably during marshalling, via the inherited
+        // beforeMarshal() -> getBounds()). Returning null here is consistent with
+        // AbstractInter.getBounds(), which is allowed to return null.
+        return (bounds != null) ? new Rectangle(bounds) : null;
     }
 
     //--------------------//


### PR DESCRIPTION
Fixes #953.

Two independent null-safety gaps make `audiveris -batch -export` abort the whole book (no MusicXML produced) on imperfect/skewed scans. Each one alone is fatal.

### 1. `StaffBarlineInter.getBounds()`
A `StaffBarline` with zero members yields a null `bounds`, and `new Rectangle(bounds)` throws — during sheet marshalling (`AbstractInter.beforeMarshal()` → `getBounds()`), which is forced in batch via `swapAllSheets`. Now returns `null` when bounds is null, consistent with `AbstractInter.getBounds()` (which is allowed to return null).

### 2. `MeasureStack.getXOffset(Point2D, Staff)`
`InterFactory.handleTimes` can pass a null point / a stack with null measure geometry, throwing `NullPointerException: Null point argument` and aborting the SYMBOLS step. Now guards point/skew/measure/border and returns `0` when geometry is missing.

### Testing
Verified by applying these exact changes on top of the 5.10.2 release build — recompiling the two classes and running `-batch -export` on photographed multi-meter parts that previously aborted with each NPE in turn. The `development` source for both methods is identical to 5.10.2, so the patch applies unchanged. Before: each page aborts at one of the two NPEs and no MusicXML is written. After: every page exports MusicXML. The guards only change behaviour on the degenerate null paths; normal scores are unaffected.

The changes are minimal (one expression + a couple of guards) and documented inline.