### PR TITLE
Fix beam look-ahead in CLinker.expand reading the current item instead of the next one

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/stem/HeadLinker.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/stem/HeadLinker.java
@@ -1184,7 +1184,7 @@ public class HeadLinker
                         boolean stop = true;
                         final BeamGroupInter group = beam.getGroup();
                         for (int j = i + 1; j <= maxIndex; j++) {
-                            final StemItem ev2 = sb.get(i);
+                            final StemItem ev2 = sb.get(j);
                             if (ev2 instanceof LinkerItem
                                     && ((LinkerItem) ev2).linker instanceof BLinker) {
                                 final BLinker bl2 = (BLinker) ((LinkerItem) ev2).linker;


### PR DESCRIPTION
One character: the beam look-ahead in `CLinker.expand()` iterated `j` but read `sb.get(i)`, so it never actually examined the items after the current beam. Fixes #976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168bXgjWpuzFPAT6kPNvup2
