### PR TITLE
Fix batch mode broken by Scale static ResourceMap

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/Scale.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/Scale.java
@@ -30,7 +30,6 @@ import org.audiveris.omr.util.param.ConstantBasedParam;
 import org.audiveris.omr.util.param.Param;
 
 import org.jdesktop.application.Application;
-import org.jdesktop.application.ResourceMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -152,9 +151,6 @@ public class Scale
     private static final Constants constants = new Constants();
 
     private static final Logger logger = LoggerFactory.getLogger(Scale.class);
-
-    private static final ResourceMap resources = Application.getInstance().getContext()
-            .getResourceMap(Scale.class);
 
     public static final Param<Integer> defaultInterlineSpecification = new ConstantBasedParam<>(
             constants.defaultInterlineSpecification,
@@ -1327,7 +1323,11 @@ public class Scale
         public String getDescription ()
         {
             if (description == null) {
-                description = resources.getString(name());
+                // NOTA: The resource map is retrieved on demand rather than kept in a static
+                // field, because Scale gets class-initialized in batch mode as well, with no
+                // application launched
+                description = Application.getInstance().getContext() //
+                        .getResourceMap(Scale.class).getString(name());
             }
 
             return description;


### PR DESCRIPTION
Fixes #980.

`Scale` acquired its `ResourceMap` in a static field:

```java
private static final ResourceMap resources = Application.getInstance().getContext()
        .getResourceMap(Scale.class);
```

`Application.getInstance()` requires a launched application, so this makes any class initialization of `Scale` fail when there is none. In batch mode that happens very early — `BookManager.loadInput` -> `new Book(...)` -> `initTransients` -> `setParamParents` reads the static `Scale.defaultInterlineSpecification` — so the run died with `ExceptionInInitializerError` before the first sheet was loaded.

The resource map is now retrieved at the single point of use, `Scale.Item.getDescription()`, whose result was already cached in `description`. Same resource map key (`Scale.class`), same string, simply resolved on first use, at which point the application is necessarily up. The now-unused `ResourceMap` import is dropped.

`Scale` was the only engine-side class carrying that pattern; the other thirteen classes introduced by 3f6d75b are UI boards, where a launched application is guaranteed.

### Verification

Built from `development` (ab9f02fea) with the patch applied:

```
app/build/install/app/bin/Audiveris -batch -export -output /tmp/out ErrorPage.pdf
...
INFO  [ErrorPage]           PartwiseBuilder 2707 | Exporting sheet(s): [#1]
INFO  [ErrorPage]             ScoreExporter 164  | Score ErrorPage exported to /tmp/out/ErrorPage.mxl
```

The same command on unpatched `development` fails with the stack trace in #980. `.omr` and `.mxl` are produced as expected.

### Separate observation, not addressed here

While in this method, the resource keys look like they may not match. `Scale.Item.getDescription()` asks for `resources.getString(name())`, i.e. `line`, `interline`, ..., but `Scale.properties` defines `Item.line.text`, `Item.interline.text`, ... The analogous enum in `Board` uses bare keys matching the enum names (`PIXEL = Pixel`), which suggests the lookup here would return null — `SheetScaling` logs `key.getDescription()`, so it would surface as `null set to 20`.

I left it alone: it is orthogonal to the crash, and the fix could go on either side (bare keys in the bundle, or `Item.` + name + `.text` in the code — the `.text` suffix being the injection convention), which is your call. I did not verify it at runtime, since it needs a launched GUI. Happy to add it to this PR or open a separate issue, whichever you prefer.
