### PR TITLE
Add optional Zig accelerator for morphology close

### DIFF
--- a/app/src/main/java/org/audiveris/omr/image/MorphoProcessor.java
+++ b/app/src/main/java/org/audiveris/omr/image/MorphoProcessor.java
@@ -24,6 +24,19 @@ package org.audiveris.omr.image;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+
 import ij.process.ByteProcessor;
 
 /**
@@ -46,6 +59,35 @@ public class MorphoProcessor
 
     private static final int MINUS = -1;
 
+    private static final String LIBRARY_PROPERTY = "audiveris.morpho.library";
+
+    private static final String WORKER_PROPERTY = "audiveris.morpho.worker";
+
+    private static final String NATIVE_SYMBOL = "musicspace_morpho_close_v1";
+
+    private static final int PROBE_RECORD_BYTES = 12;
+
+    private static final long MAX_NATIVE_BYTES = 64L * 1024 * 1024;
+
+    private static final Arena NATIVE_ARENA = Arena.ofShared();
+
+    private static final NativeState NATIVE_STATE = loadNativeState();
+
+    private static final AtomicBoolean NATIVE_CIRCUIT_OPEN =
+            new AtomicBoolean(!NATIVE_STATE.available());
+
+    private static final LongAdder NATIVE_CALLS = new LongAdder();
+
+    private static final LongAdder FALLBACK_CALLS = new LongAdder();
+
+    private static final ThreadLocal<NativeBuffers> NATIVE_BUFFERS =
+            ThreadLocal.withInitial(NativeBuffers::new);
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(MorphoProcessor::reportNativeSummary,
+                                                         "morpho-native-summary"));
+    }
+
     //~ Instance fields ----------------------------------------------------------------------------
 
     private final StructureElement se; //, down_se, up_se;
@@ -66,9 +108,137 @@ public class MorphoProcessor
 
     private final int[][] pg_minus;
 
+    private final MemorySegment flattenedProbe;
+
+    private final long flattenedProbeLength;
+
     int width;
 
     int height;
+
+    private static NativeState loadNativeState ()
+    {
+        try {
+            String library = System.getProperty(LIBRARY_PROPERTY);
+            if (library == null || library.isBlank()) {
+                throw new IOException("library_property_missing");
+            }
+
+            SymbolLookup lookup = SymbolLookup.libraryLookup(Path.of(library), NATIVE_ARENA);
+            MemorySegment symbol = lookup.findOrThrow(NATIVE_SYMBOL);
+            MethodHandle handle = Linker.nativeLinker().downcallHandle(
+                    symbol,
+                    FunctionDescriptor.of(
+                            ValueLayout.JAVA_INT,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.JAVA_LONG,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.JAVA_LONG,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.JAVA_LONG,
+                            ValueLayout.JAVA_LONG,
+                            ValueLayout.JAVA_LONG,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.JAVA_LONG));
+            return new NativeState(handle, null);
+        } catch (Throwable ex) {
+            return new NativeState(null, ex.getClass().getSimpleName());
+        }
+    }
+
+    private static MemorySegment flattenProbe (int[][] probe)
+    {
+        if (probe == null || probe.length == 0) {
+            throw new IllegalArgumentException("probe_empty");
+        }
+
+        long bytes = Math.multiplyExact((long) probe.length, PROBE_RECORD_BYTES);
+        MemorySegment flattened = NATIVE_ARENA.allocate(bytes, Integer.BYTES);
+        for (int index = 0; index < probe.length; index++) {
+            int[] row = probe[index];
+            if (row == null || row.length < 3) {
+                throw new IllegalArgumentException("probe_row_short_" + index);
+            }
+
+            long offset = (long) index * PROBE_RECORD_BYTES;
+            flattened.set(ValueLayout.JAVA_INT, offset, row[0]);
+            flattened.set(ValueLayout.JAVA_INT, offset + Integer.BYTES, row[1]);
+            flattened.set(ValueLayout.JAVA_INT, offset + (2L * Integer.BYTES), row[2]);
+        }
+        return flattened.asReadOnly();
+    }
+
+    private static void reportNativeSummary ()
+    {
+        System.err.println("MORPHO_NATIVE_SUMMARY native_calls=" + NATIVE_CALLS.sum()
+                                   + " fallback_calls=" + FALLBACK_CALLS.sum()
+                                   + " circuit_open=" + NATIVE_CIRCUIT_OPEN.get());
+    }
+
+    private static final class NativeState
+    {
+        private final MethodHandle handle;
+
+        private final String failure;
+
+        private NativeState (MethodHandle handle,
+                             String failure)
+        {
+            this.handle = handle;
+            this.failure = failure;
+        }
+
+        private boolean available ()
+        {
+            return handle != null;
+        }
+    }
+
+    private static final class NativeBuffers
+    {
+        private Arena arena;
+
+        private MemorySegment input;
+
+        private MemorySegment scratch;
+
+        private MemorySegment output;
+
+        private long capacity;
+
+        private void ensure (long bytes)
+                throws IOException
+        {
+            if (bytes <= 0 || bytes > MAX_NATIVE_BYTES) {
+                throw new IOException("native_plane_too_large");
+            }
+            if (capacity >= bytes) {
+                return;
+            }
+
+            Arena replacement = Arena.ofConfined();
+            try {
+                MemorySegment replacementInput = replacement.allocate(bytes, 1);
+                MemorySegment replacementScratch = replacement.allocate(bytes, 1);
+                MemorySegment replacementOutput = replacement.allocate(bytes, 1);
+                Arena previous = arena;
+                arena = replacement;
+                input = replacementInput;
+                scratch = replacementScratch;
+                output = replacementOutput;
+                capacity = bytes;
+                if (previous != null) {
+                    previous.close();
+                }
+            } catch (Throwable ex) {
+                replacement.close();
+                if (ex instanceof IOException io) {
+                    throw io;
+                }
+                throw new IOException("native_buffer_allocation_failed", ex);
+            }
+        }
+    }
 
     //~ Constructors -------------------------------------------------------------------------------
 
@@ -90,6 +260,8 @@ public class MorphoProcessor
         pg = se.getVect();
         pg_plus = plus_se.getVect();
         pg_minus = minus_se.getVect();
+        flattenedProbe = flattenProbe(pg);
+        flattenedProbeLength = pg.length;
     }
 
     //~ Methods ------------------------------------------------------------------------------------
@@ -104,6 +276,25 @@ public class MorphoProcessor
      * @param ip the ImageProcessor
      */
     public void close (ByteProcessor ip)
+    {
+        try {
+            byte[] pixels = (byte[]) ip.getPixels();
+            closeWithWorker(ip.getWidth(), ip.getHeight(), pixels);
+            NATIVE_CALLS.increment();
+            return;
+        } catch (Exception ex) {
+            FALLBACK_CALLS.increment();
+        }
+
+        closeJavaFallback(ip);
+    }
+
+    /**
+     * The original Java close implementation, retained as a fail-closed fallback.
+     *
+     * @param ip the ImageProcessor
+     */
+    private void closeJavaFallback (ByteProcessor ip)
     {
         int width = ip.getWidth();
         int height = ip.getHeight();
@@ -153,6 +344,110 @@ public class MorphoProcessor
         }
 
         System.arraycopy(newpix2, 0, pixels, 0, pixels.length);
+    }
+
+    private void closeWithWorker (int imageWidth,
+                                  int imageHeight,
+                                  byte[] pixels)
+            throws IOException
+    {
+        if (imageWidth <= 0 || imageHeight <= 0) {
+            throw new IOException("invalid_dimensions");
+        }
+
+        long expectedLength = (long) imageWidth * imageHeight;
+        if (expectedLength != pixels.length || expectedLength > Integer.MAX_VALUE) {
+            throw new IOException("pixel_length_mismatch");
+        }
+
+        if (NATIVE_CIRCUIT_OPEN.get()) {
+            throw new IOException("native_circuit_open");
+        }
+
+        NativeBuffers buffers = NATIVE_BUFFERS.get();
+        MemorySegment heapPixels = MemorySegment.ofArray(pixels);
+        try {
+            buffers.ensure(expectedLength);
+            MemorySegment.copy(heapPixels, 0, buffers.input, 0, expectedLength);
+            int status = (int) NATIVE_STATE.handle.invokeExact(
+                    buffers.input,
+                    expectedLength,
+                    buffers.scratch,
+                    expectedLength,
+                    buffers.output,
+                    expectedLength,
+                    (long) imageWidth,
+                    (long) imageHeight,
+                    flattenedProbe,
+                    flattenedProbeLength);
+            if (status != 0) {
+                throw new IOException("native_status_" + status);
+            }
+
+            MemorySegment.copy(buffers.output, 0, heapPixels, 0, expectedLength);
+        } catch (Throwable ex) {
+            NATIVE_CIRCUIT_OPEN.set(true);
+            if (ex instanceof IOException io) {
+                throw io;
+            }
+            throw new IOException("native_call_failed", ex);
+        }
+    }
+
+    private static byte[] encodeProbe (int[][] probe)
+    {
+        if (probe == null || probe.length == 0) {
+            throw new IllegalArgumentException("probe_empty");
+        }
+
+        byte[] encoded = new byte[Math.multiplyExact(probe.length, PROBE_RECORD_BYTES)];
+        for (int index = 0; index < probe.length; index++) {
+            int[] row = probe[index];
+            if (row == null || row.length < 3) {
+                throw new IllegalArgumentException("probe_row_short_" + index);
+            }
+
+            int offset = index * PROBE_RECORD_BYTES;
+            writeLittleEndian(encoded, offset, row[0]);
+            writeLittleEndian(encoded, offset + 4, row[1]);
+            writeLittleEndian(encoded, offset + 8, row[2]);
+        }
+        return encoded;
+    }
+
+    private static void writeLittleEndian (byte[] target,
+                                           int offset,
+                                           int value)
+    {
+        target[offset] = (byte) value;
+        target[offset + 1] = (byte) (value >>> 8);
+        target[offset + 2] = (byte) (value >>> 16);
+        target[offset + 3] = (byte) (value >>> 24);
+    }
+
+    private static void reportNative (String status,
+                                      long started,
+                                      int imageWidth,
+                                      int imageHeight,
+                                      int bytes,
+                                      String detail)
+    {
+        long elapsed = System.nanoTime() - started;
+        System.err.println("MORPHO_NATIVE status=" + status
+                                   + " elapsed_ns=" + elapsed
+                                   + " width=" + imageWidth
+                                   + " height=" + imageHeight
+                                   + " bytes=" + bytes
+                                   + " detail=" + detail);
+    }
+
+    private static String sanitize (Exception ex)
+    {
+        String detail = ex.getClass().getSimpleName();
+        if (ex.getMessage() != null && !ex.getMessage().isBlank()) {
+            detail += "_" + ex.getMessage().replaceAll("[^A-Za-z0-9_.-]", "_");
+        }
+        return detail;
     }
 
     //--------//

--- a/native/morpho-close/BENCHMARKS.md
+++ b/native/morpho-close/BENCHMARKS.md
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Measured parity and performance
+
+The implementation was measured on Apple Silicon macOS with Java 25 and Zig
+0.16.0. Stock and native runs used identical Audiveris builds, input bytes and
+batch settings. MusicXML comparison removed only the volatile `encoding-date`;
+the remaining XML bytes were exact.
+
+## Initial five sheets
+
+| Sheet | Stock, s | Zig native, s | Improvement |
+|---|---:|---:|---:|
+| Pirate cold | 25.649 | 15.826 | 38.298% |
+| Pirate warm p50 | 22.876 | 14.543 | 36.427% |
+| Pirate warm p95 | 23.654 | 14.719 | 37.774% |
+| Saint-Saëns | 26.966 | 16.926 | 37.232% |
+| Moszkowski | 20.374 | 13.768 | 32.424% |
+| Weber/Liszt | 18.740 | 13.262 | 29.232% |
+| Berlioz/Liszt | 23.921 | 16.995 | 28.954% |
+
+All 20 processes exited successfully. Every native run reported nonzero native
+calls, zero fallback calls and `circuit_open=false`. Pirate was measured once
+cold and five times warm per route. Every normalized MusicXML pair was exact.
+
+## Additional 20-sheet corpus
+
+Seventeen stock/native pairs exported successfully and had exact normalized
+MusicXML parity. Three inputs produced the same early rejection or export
+failure on both routes and are not counted as successful recognition claims.
+
+Across the 17 successful exports, stock totaled 216.73 seconds and native
+167.87 seconds: a 22.544% wall-clock improvement. Across all 20 observed pairs,
+including matched failures, totals were 240.83 and 190.29 seconds: a 20.986%
+improvement. Every successful native run was faster; individual improvement
+ranged from 4.253% to 42.430%.
+
+## Evidence boundary
+
+- These are wall-clock measurements from one Apple Silicon macOS machine, not
+  a cross-platform guarantee.
+- The measurements cover the optional morphology path, not a change to OMR
+  models or musical interpretation.
+- Raw MXL containers may contain volatile metadata. The exact parity claim is
+  for extracted score XML after replacing only `encoding-date`.
+- The three matched failures prove equivalent failure behavior only; they do
+  not count as successful exports.

--- a/native/morpho-close/LICENSE
+++ b/native/morpho-close/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/native/morpho-close/NOTICE
+++ b/native/morpho-close/NOTICE
@@ -1,0 +1,15 @@
+SPDX-License-Identifier: AGPL-3.0-only
+
+AGPL-3.0 source-offer notice
+----------------------------
+
+This isolated worker is distributed as corresponding source under the GNU
+Affero General Public License version 3 only. The complete corresponding
+source is the contents of this package directory: Zig sources, the frozen
+morphology candidate and ABI, C header, build definition, tests, and protocol
+documentation.
+
+If this worker is conveyed or run as a network service, preserve the AGPL
+notices and provide recipients/users with access to the corresponding source
+for the exact version used. The canonical AGPL-3.0 text is referenced by
+LICENSE.

--- a/native/morpho-close/README.md
+++ b/native/morpho-close/README.md
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Optional Zig accelerator for Audiveris morphology close
+
+This directory contains the complete source for an optional CPU accelerator
+for `MorphoProcessor.close`. The shared library exposes one versioned C ABI and
+is loaded once by the Java 25 Foreign Function and Memory bridge in Audiveris.
+Each close operation crosses the boundary once with a complete grayscale image
+plane; no helper process or temporary file is used in the hot path.
+
+The original Java implementation remains the fail-closed fallback. If the
+native library is not configured, cannot be loaded, returns an error or fails
+during execution, Audiveris continues through the stock Java path.
+
+## Requirements
+
+- Zig 0.16.0;
+- Java 25 for the optional Audiveris FFM integration;
+- a platform supported by Zig's shared-library output.
+
+The published measurements cover Apple Silicon macOS only. See
+[BENCHMARKS.md](BENCHMARKS.md) for the exact evidence and non-claims.
+
+## Build and test
+
+From this directory:
+
+```sh
+zig fmt --check build.zig src
+zig build test
+zig build -Doptimize=ReleaseFast
+```
+
+The build installs:
+
+- `zig-out/lib/libmusicspace_morpho_close_v1.*`, the shared library used by
+  the Java FFM path;
+- `zig-out/bin/audiveris-morpho-worker`, a diagnostic CLI for differential
+  checks outside the Audiveris hot path.
+
+## Enable the optional path
+
+Run Audiveris with Java 25, enable native access for the unnamed module and set
+the absolute shared-library path:
+
+```text
+--enable-native-access=ALL-UNNAMED
+-Daudiveris.morpho.library=/absolute/path/to/libmusicspace_morpho_close_v1.dylib
+```
+
+Use the platform-specific shared-library extension on Linux or Windows. When
+the property is absent, the native circuit remains disabled and the existing
+Java implementation is used.
+
+At JVM shutdown the bridge prints one summary containing `native_calls`,
+`fallback_calls` and `circuit_open`. A valid native benchmark requires a
+positive native-call count, zero fallback calls and a closed circuit breaker.
+
+## C ABI
+
+The shared library exports `musicspace_morpho_close_v1`. Matching declarations
+and stable status values are in
+[`include/musicspace_morpho_close_v1.h`](include/musicspace_morpho_close_v1.h).
+The function receives caller-owned input, scratch and output planes plus one
+flattened morphology probe. It validates all pointers, lengths, dimensions and
+overlaps before processing and performs no file I/O or allocation.
+
+The diagnostic worker protocol is documented in
+[WORKER_PROTOCOL_V1.md](WORKER_PROTOCOL_V1.md).
+
+## License
+
+This component and its corresponding source are distributed under
+AGPL-3.0-only. See [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/native/morpho-close/WORKER_PROTOCOL_V1.md
+++ b/native/morpho-close/WORKER_PROTOCOL_V1.md
@@ -1,0 +1,87 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Worker protocol v1
+
+The worker is intentionally bounded to one deterministic file operation:
+
+```text
+audiveris-morpho-worker close --width W --height H --input INPUT.raw --probe PROBE.bin --output OUTPUT.raw
+```
+
+Arguments must appear in this order with no additional arguments. `W` and `H`
+are base-10 unsigned `size_t` values and must be nonzero. The input path,
+probe path, and output path must be nonempty.
+
+## Files
+
+- `INPUT.raw`: exactly `W*H` bytes, one grayscale byte per pixel in row-major
+  order.
+- `PROBE.bin`: a nonempty byte sequence whose length is divisible by 12. Each
+  record is three little-endian signed 32-bit integers in this order:
+  `{dy, dx, weight}`.
+- `OUTPUT.raw`: exactly `W*H` bytes, published only after input/probe
+  validation and morphology return `ok`.
+
+The process reads all inputs and decodes all probes before invoking the frozen
+ABI. It writes a sibling `OUTPUT.raw.part` only after a successful morphology,
+then closes and renames it into place. A failed validation, morphology, write,
+or rename returns nonzero and leaves no worker-created partial output.
+
+## Stable status line
+
+The process writes one machine-readable line to standard error:
+
+```text
+status=<status-name> code=<u32-code> <human-detail>
+```
+
+The code and name are the frozen ABI statuses:
+
+| Code | Name |
+| ---: | --- |
+| 0 | `ok` |
+| 1 | `zero_width` |
+| 2 | `zero_height` |
+| 3 | `zero_taps` |
+| 4 | `wrong_input_length` |
+| 5 | `wrong_scratch_length` |
+| 6 | `wrong_output_length` |
+| 7 | `input_scratch_overlap` |
+| 8 | `scratch_output_overlap` |
+| 9 | `input_output_overlap` |
+| 10 | `dimension_overflow` |
+| 11 | `null_pointer` |
+| 12 | `arithmetic_overflow` |
+
+CLI parse, filesystem, allocation, and atomic-publication failures are mapped
+to the same stable status domain. A malformed input/probe length maps to
+`wrong_input_length`; an empty probe maps to `zero_taps`.
+
+## C ABI
+
+The shared library exports:
+
+```c
+musicspace_morpho_status_v1 musicspace_morpho_close_v1(
+    const uint8_t *input_ptr,
+    size_t input_len,
+    uint8_t *scratch_ptr,
+    size_t scratch_len,
+    uint8_t *output_ptr,
+    size_t output_len,
+    size_t width,
+    size_t height,
+    const musicspace_morpho_tap_v1 *taps_ptr,
+    size_t taps_len);
+```
+
+The ABI validates zero dimensions/taps, dimension multiplication, exact buffer
+lengths, null pointers, checked pointer ends, and pairwise overlap before
+running the selected generic or binary fast path. ABI callers own all buffers;
+the function does not create files.
+
+## Scope
+
+This is an isolated CPU exactness seam. A passing worker report does not claim
+full Audiveris integration, Java bridge integration, production readiness,
+canonical admission, or a full-Audiveris speedup.

--- a/native/morpho-close/build.zig
+++ b/native/morpho-close/build.zig
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+// with this package; see README.md and NOTICE for the source-offer notice.
+
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const library = b.addLibrary(.{
+        .name = "musicspace_morpho_close_v1",
+        .linkage = .dynamic,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/library.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    b.installArtifact(library);
+
+    const worker = b.addExecutable(.{
+        .name = "audiveris-morpho-worker",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/worker.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    b.installArtifact(worker);
+
+    const test_artifact = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/morpho_close_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_tests = b.addRunArtifact(test_artifact);
+    const test_step = b.step("test", "Run focused ABI, kernel, and protocol tests");
+    test_step.dependOn(&run_tests.step);
+}

--- a/native/morpho-close/include/musicspace_morpho_close_v1.h
+++ b/native/morpho-close/include/musicspace_morpho_close_v1.h
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: AGPL-3.0-only */
+/*
+ * Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+ * with this package; see README.md and NOTICE for the source-offer notice.
+ */
+
+#ifndef MUSICSPACE_MORPHO_CLOSE_V1_H
+#define MUSICSPACE_MORPHO_CLOSE_V1_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct musicspace_morpho_tap_v1 {
+    int32_t dy;
+    int32_t dx;
+    int32_t weight;
+} musicspace_morpho_tap_v1;
+
+typedef enum musicspace_morpho_status_v1 {
+    MUSICSPACE_MORPHO_OK = 0,
+    MUSICSPACE_MORPHO_ZERO_WIDTH = 1,
+    MUSICSPACE_MORPHO_ZERO_HEIGHT = 2,
+    MUSICSPACE_MORPHO_ZERO_TAPS = 3,
+    MUSICSPACE_MORPHO_WRONG_INPUT_LENGTH = 4,
+    MUSICSPACE_MORPHO_WRONG_SCRATCH_LENGTH = 5,
+    MUSICSPACE_MORPHO_WRONG_OUTPUT_LENGTH = 6,
+    MUSICSPACE_MORPHO_INPUT_SCRATCH_OVERLAP = 7,
+    MUSICSPACE_MORPHO_SCRATCH_OUTPUT_OVERLAP = 8,
+    MUSICSPACE_MORPHO_INPUT_OUTPUT_OVERLAP = 9,
+    MUSICSPACE_MORPHO_DIMENSION_OVERFLOW = 10,
+    MUSICSPACE_MORPHO_NULL_POINTER = 11,
+    MUSICSPACE_MORPHO_ARITHMETIC_OVERFLOW = 12,
+} musicspace_morpho_status_v1;
+
+musicspace_morpho_status_v1 musicspace_morpho_close_v1(
+    const uint8_t *input_ptr,
+    size_t input_len,
+    uint8_t *scratch_ptr,
+    size_t scratch_len,
+    uint8_t *output_ptr,
+    size_t output_len,
+    size_t width,
+    size_t height,
+    const musicspace_morpho_tap_v1 *taps_ptr,
+    size_t taps_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/native/morpho-close/src/library.zig
+++ b/native/morpho-close/src/library.zig
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+// with this package; see README.md and NOTICE for the source-offer notice.
+
+const abi = @import("morpho_close_abi.zig");
+const candidate = @import("morpho_close_fast_candidate_r1.zig");
+
+pub fn closeInto(
+    input_ptr: ?[*]const u8,
+    input_len: usize,
+    scratch_ptr: ?[*]u8,
+    scratch_len: usize,
+    output_ptr: ?[*]u8,
+    output_len: usize,
+    width: usize,
+    height: usize,
+    taps_ptr: ?[*]const abi.Tap,
+    taps_len: usize,
+) callconv(.c) abi.Status {
+    return candidate.closeInto(
+        input_ptr,
+        input_len,
+        scratch_ptr,
+        scratch_len,
+        output_ptr,
+        output_len,
+        width,
+        height,
+        taps_ptr,
+        taps_len,
+    );
+}
+
+pub export fn musicspace_morpho_close_v1(
+    input_ptr: ?[*]const u8,
+    input_len: usize,
+    scratch_ptr: ?[*]u8,
+    scratch_len: usize,
+    output_ptr: ?[*]u8,
+    output_len: usize,
+    width: usize,
+    height: usize,
+    taps_ptr: ?[*]const abi.Tap,
+    taps_len: usize,
+) callconv(.c) abi.Status {
+    return closeInto(
+        input_ptr,
+        input_len,
+        scratch_ptr,
+        scratch_len,
+        output_ptr,
+        output_len,
+        width,
+        height,
+        taps_ptr,
+        taps_len,
+    );
+}

--- a/native/morpho-close/src/morpho_close_abi.zig
+++ b/native/morpho-close/src/morpho_close_abi.zig
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+// with this package; see README.md and NOTICE for the source-offer notice.
+
+pub const Tap = extern struct {
+    dy: i32,
+    dx: i32,
+    weight: i32,
+};
+
+pub const Status = enum(u32) {
+    ok = 0,
+    zero_width = 1,
+    zero_height = 2,
+    zero_taps = 3,
+    wrong_input_length = 4,
+    wrong_scratch_length = 5,
+    wrong_output_length = 6,
+    input_scratch_overlap = 7,
+    scratch_output_overlap = 8,
+    input_output_overlap = 9,
+    dimension_overflow = 10,
+    null_pointer = 11,
+    arithmetic_overflow = 12,
+};
+
+pub const CloseFn = *const fn (
+    input_ptr: ?[*]const u8,
+    input_len: usize,
+    scratch_ptr: ?[*]u8,
+    scratch_len: usize,
+    output_ptr: ?[*]u8,
+    output_len: usize,
+    width: usize,
+    height: usize,
+    taps_ptr: ?[*]const Tap,
+    taps_len: usize,
+) callconv(.c) Status;

--- a/native/morpho-close/src/morpho_close_fast_candidate_r1.zig
+++ b/native/morpho-close/src/morpho_close_fast_candidate_r1.zig
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+// with this package; see README.md and NOTICE for the source-offer notice.
+
+const std = @import("std");
+const abi = @import("morpho_close_abi.zig");
+const gray = @import("morpho_close_gray_fast_r3.zig");
+
+const usize_max: usize = ~@as(usize, 0);
+const i32_max: i32 = @bitCast(@as(u32, 0x7fffffff));
+const i32_min: i32 = @bitCast(@as(u32, 0x80000000));
+
+// The fast kernel has no dimension-dependent stack storage. These bounds make
+// its local word arithmetic explicit and keep every packed offset checked.
+const fast_max_words_per_row: usize = 1 << 15;
+const fast_max_height: usize = 1 << 20;
+const fast_max_taps: usize = 4096;
+
+const ValidatedCall = struct {
+    input: [*]const u8,
+    scratch: [*]u8,
+    output: [*]u8,
+    taps: [*]const abi.Tap,
+    pixel_count: usize,
+};
+
+const Validation = union(enum) {
+    status: abi.Status,
+    ok: ValidatedCall,
+};
+
+const FastLayout = struct {
+    words_per_row: usize,
+    valid_last_bits: usize,
+    last_mask: u64,
+    packed_row_len: usize,
+    word_count: usize,
+    packed_len: usize,
+};
+
+fn checkedEnd(start: usize, length: usize) ?usize {
+    if (length > usize_max - start) return null;
+    return start + length;
+}
+
+fn rangesOverlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) bool {
+    return a_start < b_end and b_start < a_end;
+}
+
+fn addChecked(a: i32, b: i32) ?i32 {
+    if (b > 0 and a > i32_max - b) return null;
+    if (b < 0 and a < i32_min - b) return null;
+    return a + b;
+}
+
+fn subChecked(a: i32, b: i32) ?i32 {
+    if (b > 0 and a < i32_min + b) return null;
+    if (b < 0 and a > i32_max + b) return null;
+    return a - b;
+}
+
+fn shifted(base: usize, delta: i32, limit: usize) ?usize {
+    const coordinate: i128 = @as(i128, @intCast(base)) + @as(i128, @intCast(delta));
+    const signed_limit: i128 = @intCast(limit);
+    if (coordinate < 0 or coordinate >= signed_limit) return null;
+    return @intCast(coordinate);
+}
+
+fn wrappedPlusOne(value: i32) u8 {
+    const bits: u32 = @bitCast(value);
+    const raw: u8 = @truncate(bits);
+    return raw +% 1;
+}
+
+fn wrappedMinusOne(value: i32) u8 {
+    const bits: u32 = @bitCast(value);
+    const raw: u8 = @truncate(bits);
+    return raw -% 1;
+}
+
+fn validate(
+    input_ptr: ?[*]const u8,
+    input_len: usize,
+    scratch_ptr: ?[*]u8,
+    scratch_len: usize,
+    output_ptr: ?[*]u8,
+    output_len: usize,
+    width: usize,
+    height: usize,
+    taps_ptr: ?[*]const abi.Tap,
+    taps_len: usize,
+) Validation {
+    if (width == 0) return .{ .status = .zero_width };
+    if (height == 0) return .{ .status = .zero_height };
+    if (taps_len == 0) return .{ .status = .zero_taps };
+
+    if (width > usize_max / height) return .{ .status = .dimension_overflow };
+    const pixel_count = width * height;
+
+    if (input_len != pixel_count) return .{ .status = .wrong_input_length };
+    if (scratch_len != pixel_count) return .{ .status = .wrong_scratch_length };
+    if (output_len != pixel_count) return .{ .status = .wrong_output_length };
+
+    const input = input_ptr orelse return .{ .status = .null_pointer };
+    const scratch = scratch_ptr orelse return .{ .status = .null_pointer };
+    const output = output_ptr orelse return .{ .status = .null_pointer };
+    const taps = taps_ptr orelse return .{ .status = .null_pointer };
+
+    const input_start = @intFromPtr(input);
+    const scratch_start = @intFromPtr(scratch);
+    const output_start = @intFromPtr(output);
+    const input_end = checkedEnd(input_start, input_len) orelse return .{ .status = .arithmetic_overflow };
+    const scratch_end = checkedEnd(scratch_start, scratch_len) orelse return .{ .status = .arithmetic_overflow };
+    const output_end = checkedEnd(output_start, output_len) orelse return .{ .status = .arithmetic_overflow };
+
+    if (rangesOverlap(input_start, input_end, scratch_start, scratch_end)) {
+        return .{ .status = .input_scratch_overlap };
+    }
+    if (rangesOverlap(scratch_start, scratch_end, output_start, output_end)) {
+        return .{ .status = .scratch_output_overlap };
+    }
+    if (rangesOverlap(input_start, input_end, output_start, output_end)) {
+        return .{ .status = .input_output_overlap };
+    }
+
+    return .{ .ok = .{
+        .input = input,
+        .scratch = scratch,
+        .output = output,
+        .taps = taps,
+        .pixel_count = pixel_count,
+    } };
+}
+
+fn dilationSample(
+    input: [*]const u8,
+    width: usize,
+    height: usize,
+    y: usize,
+    x: usize,
+    tap: abi.Tap,
+) u8 {
+    const source_y = shifted(y, tap.dy, height) orelse return 0;
+    const source_x = shifted(x, tap.dx, width) orelse return 0;
+    return input[source_y * width + source_x];
+}
+
+fn erosionSample(
+    scratch: [*]const u8,
+    width: usize,
+    height: usize,
+    y: usize,
+    x: usize,
+    tap: abi.Tap,
+) u8 {
+    const source_y = shifted(y, tap.dy, height) orelse return 255;
+    const source_x = shifted(x, tap.dx, width) orelse return 255;
+    return scratch[source_y * width + source_x];
+}
+
+fn genericClose(call: ValidatedCall, width: usize, height: usize, taps_len: usize) abi.Status {
+    var pixel_index: usize = 0;
+    while (pixel_index < call.pixel_count) : (pixel_index += 1) {
+        const y = pixel_index / width;
+        const x = pixel_index % width;
+        var aggregate: i32 = i32_min;
+
+        var tap_index: usize = 0;
+        while (tap_index < taps_len) : (tap_index += 1) {
+            const tap = call.taps[tap_index];
+            const sample = dilationSample(call.input, width, height, y, x, tap);
+            const score = addChecked(@intCast(sample), tap.weight) orelse return .arithmetic_overflow;
+            if (score > aggregate) aggregate = score;
+        }
+        call.scratch[pixel_index] = wrappedPlusOne(aggregate);
+    }
+
+    pixel_index = 0;
+    while (pixel_index < call.pixel_count) : (pixel_index += 1) {
+        const y = pixel_index / width;
+        const x = pixel_index % width;
+        var aggregate: i32 = i32_max;
+
+        var tap_index: usize = 0;
+        while (tap_index < taps_len) : (tap_index += 1) {
+            const tap = call.taps[tap_index];
+            const sample = erosionSample(call.scratch, width, height, y, x, tap);
+            const score = subChecked(@intCast(sample), tap.weight) orelse return .arithmetic_overflow;
+            if (score < aggregate) aggregate = score;
+        }
+        call.output[pixel_index] = wrappedMinusOne(aggregate);
+    }
+
+    return .ok;
+}
+
+fn fastLayout(width: usize, height: usize, taps_len: usize, pixel_count: usize) ?FastLayout {
+    if (width > fast_max_words_per_row * 64) return null;
+    if (height > fast_max_height) return null;
+    if (taps_len > fast_max_taps) return null;
+
+    const words_per_row = width / 64 + @as(usize, if (width % 64 == 0) 0 else 1);
+    if (words_per_row == 0 or words_per_row > fast_max_words_per_row) return null;
+    if (words_per_row > usize_max / height) return null;
+    const word_count = words_per_row * height;
+    if (word_count > usize_max / 8) return null;
+    const packed_len = word_count * 8;
+    if (packed_len > pixel_count) return null;
+    if (words_per_row > usize_max / 8) return null;
+    const packed_row_len = words_per_row * 8;
+
+    const valid_last_bits = if (width % 64 == 0) 64 else width % 64;
+    const last_mask: u64 = if (valid_last_bits == 64)
+        ~@as(u64, 0)
+    else
+        (@as(u64, 1) << @as(u6, @intCast(valid_last_bits))) - 1;
+
+    return .{
+        .words_per_row = words_per_row,
+        .valid_last_bits = valid_last_bits,
+        .last_mask = last_mask,
+        .packed_row_len = packed_row_len,
+        .word_count = word_count,
+        .packed_len = packed_len,
+    };
+}
+
+inline fn loadWordAt(bytes: [*]const u8, offset: usize) u64 {
+    return std.mem.readInt(u64, @ptrCast(bytes + offset), .little);
+}
+
+inline fn storeWordAt(bytes: [*]u8, offset: usize, value: u64) void {
+    std.mem.writeInt(u64, @ptrCast(bytes + offset), value, .little);
+}
+
+fn loadWord(
+    row: [*]const u8,
+    word_index: i128,
+    words_per_row: usize,
+    last_mask: u64,
+    fill: u64,
+) u64 {
+    if (word_index < 0 or word_index >= @as(i128, @intCast(words_per_row))) return fill;
+
+    const index: usize = @intCast(word_index);
+    const word = loadWordAt(row, index * 8);
+    if (index == words_per_row - 1) {
+        return (word & last_mask) | (fill & ~last_mask);
+    }
+    return word;
+}
+
+fn shiftedWord(
+    row: [*]const u8,
+    output_word: usize,
+    dx: i32,
+    words_per_row: usize,
+    last_mask: u64,
+    fill: u64,
+) u64 {
+    const base_bit: i128 = @as(i128, @intCast(output_word)) * 64 + @as(i128, @intCast(dx));
+    const source_word: i128 = @divFloor(base_bit, @as(i128, 64));
+    const shift: u6 = @intCast(@mod(base_bit, @as(i128, 64)));
+    const low = loadWord(row, source_word, words_per_row, last_mask, fill);
+    if (shift == 0) return low;
+
+    const high = loadWord(row, source_word + 1, words_per_row, last_mask, fill);
+    const reverse_shift: u6 = @intCast(64 - @as(u7, shift));
+    return (low >> shift) | (high << reverse_shift);
+}
+
+fn fastPreflight(
+    input: [*]const u8,
+    pixel_count: usize,
+    taps: [*]const abi.Tap,
+    taps_len: usize,
+) bool {
+    var tap_index: usize = 0;
+    while (tap_index < taps_len) : (tap_index += 1) {
+        if (taps[tap_index].weight != 255) return false;
+    }
+
+    var pixel_index: usize = 0;
+    while (pixel_index < pixel_count) : (pixel_index += 1) {
+        const value = input[pixel_index];
+        if (value != 0 and value != 255) return false;
+    }
+
+    return true;
+}
+
+fn fastPathLayout(
+    input: [*]const u8,
+    pixel_count: usize,
+    width: usize,
+    height: usize,
+    taps: [*]const abi.Tap,
+    taps_len: usize,
+) ?FastLayout {
+    const layout = fastLayout(width, height, taps_len, pixel_count) orelse return null;
+    if (!fastPreflight(input, pixel_count, taps, taps_len)) return null;
+    return layout;
+}
+
+pub fn fastPathEligible(
+    input: []const u8,
+    width: usize,
+    height: usize,
+    taps: []const abi.Tap,
+) bool {
+    if (width == 0 or height == 0 or taps.len == 0) return false;
+    if (width > usize_max / height) return false;
+    const pixel_count = width * height;
+    if (input.len != pixel_count) return false;
+    return fastPathLayout(input.ptr, pixel_count, width, height, taps.ptr, taps.len) != null;
+}
+
+fn packInput(call: ValidatedCall, width: usize, height: usize, layout: FastLayout) void {
+    var y: usize = 0;
+    while (y < height) : (y += 1) {
+        const input_row = y * width;
+        const packed_row = y * layout.packed_row_len;
+        var word: usize = 0;
+        while (word < layout.words_per_row) : (word += 1) {
+            const first_x = word * 64;
+            const remaining = width - first_x;
+            const bit_count = if (remaining < 64) remaining else 64;
+            var bits: u64 = 0;
+
+            var bit: usize = 0;
+            while (bit < bit_count) : (bit += 1) {
+                if (call.input[input_row + first_x + bit] == 255) {
+                    bits |= @as(u64, 1) << @as(u6, @intCast(bit));
+                }
+            }
+            storeWordAt(call.output, packed_row + word * 8, bits);
+        }
+    }
+}
+
+fn fastClose(call: ValidatedCall, width: usize, height: usize, taps_len: usize, layout: FastLayout) void {
+    packInput(call, width, height, layout);
+
+    var y: usize = 0;
+    while (y < height) : (y += 1) {
+        const destination_row = y * layout.packed_row_len;
+        var word: usize = 0;
+        while (word < layout.words_per_row) : (word += 1) {
+            var aggregate: u64 = 0;
+
+            var tap_index: usize = 0;
+            while (tap_index < taps_len) : (tap_index += 1) {
+                const tap = call.taps[tap_index];
+                const source_y: i128 = @as(i128, @intCast(y)) + @as(i128, @intCast(tap.dy));
+                if (source_y < 0 or source_y >= @as(i128, @intCast(height))) {
+                    continue;
+                }
+
+                const source_row = @as(usize, @intCast(source_y)) * layout.packed_row_len;
+                aggregate |= shiftedWord(
+                    call.output + source_row,
+                    word,
+                    tap.dx,
+                    layout.words_per_row,
+                    layout.last_mask,
+                    0,
+                );
+            }
+
+            if (word == layout.words_per_row - 1) aggregate &= layout.last_mask;
+            storeWordAt(call.scratch, destination_row + word * 8, aggregate);
+        }
+    }
+
+    y = 0;
+    while (y < height) : (y += 1) {
+        const destination_row = y * layout.packed_row_len;
+        var word: usize = 0;
+        while (word < layout.words_per_row) : (word += 1) {
+            var aggregate: u64 = ~@as(u64, 0);
+
+            var tap_index: usize = 0;
+            while (tap_index < taps_len) : (tap_index += 1) {
+                const tap = call.taps[tap_index];
+                const source_y: i128 = @as(i128, @intCast(y)) + @as(i128, @intCast(tap.dy));
+                if (source_y < 0 or source_y >= @as(i128, @intCast(height))) {
+                    continue;
+                }
+
+                const source_row = @as(usize, @intCast(source_y)) * layout.packed_row_len;
+                aggregate &= shiftedWord(
+                    call.scratch + source_row,
+                    word,
+                    tap.dx,
+                    layout.words_per_row,
+                    layout.last_mask,
+                    ~@as(u64, 0),
+                );
+            }
+
+            if (word == layout.words_per_row - 1) aggregate &= layout.last_mask;
+            storeWordAt(call.output, destination_row + word * 8, aggregate);
+        }
+    }
+
+    y = height;
+    while (y > 0) {
+        y -= 1;
+        const destination_row = y * width;
+        const packed_row = y * layout.packed_row_len;
+        var word = layout.words_per_row;
+        while (word > 0) {
+            word -= 1;
+            const bits_offset = packed_row + word * 8;
+            var bits = loadWordAt(call.scratch, bits_offset);
+            const first_x = word * 64;
+            const remaining = width - first_x;
+            const bit_count = if (remaining < 64) remaining else 64;
+
+            var bit: usize = 0;
+            while (bit < bit_count) : (bit += 1) {
+                call.scratch[destination_row + first_x + bit] = if ((bits & 1) != 0) 255 else 0;
+                bits >>= 1;
+            }
+        }
+    }
+
+    y = height;
+    while (y > 0) {
+        y -= 1;
+        const destination_row = y * width;
+        const packed_row = y * layout.packed_row_len;
+        var word = layout.words_per_row;
+        while (word > 0) {
+            word -= 1;
+            const bits_offset = packed_row + word * 8;
+            var bits = loadWordAt(call.output, bits_offset);
+            const first_x = word * 64;
+            const remaining = width - first_x;
+            const bit_count = if (remaining < 64) remaining else 64;
+
+            var bit: usize = 0;
+            while (bit < bit_count) : (bit += 1) {
+                call.output[destination_row + first_x + bit] = if ((bits & 1) != 0) 255 else 0;
+                bits >>= 1;
+            }
+        }
+    }
+}
+
+pub fn closeInto(
+    input_ptr: ?[*]const u8,
+    input_len: usize,
+    scratch_ptr: ?[*]u8,
+    scratch_len: usize,
+    output_ptr: ?[*]u8,
+    output_len: usize,
+    width: usize,
+    height: usize,
+    taps_ptr: ?[*]const abi.Tap,
+    taps_len: usize,
+) callconv(.c) abi.Status {
+    const validation = validate(
+        input_ptr,
+        input_len,
+        scratch_ptr,
+        scratch_len,
+        output_ptr,
+        output_len,
+        width,
+        height,
+        taps_ptr,
+        taps_len,
+    );
+    const call: ValidatedCall = switch (validation) {
+        .status => |status| return status,
+        .ok => |valid| valid,
+    };
+
+    if (gray.tryClose(call.input, call.scratch, call.output, width, height, call.taps, taps_len)) return .ok;
+
+    if (fastPathLayout(
+        call.input,
+        call.pixel_count,
+        width,
+        height,
+        call.taps,
+        taps_len,
+    )) |layout| {
+        fastClose(call, width, height, taps_len, layout);
+        return .ok;
+    }
+
+    return genericClose(call, width, height, taps_len);
+}

--- a/native/morpho-close/src/morpho_close_gray_fast_r3.zig
+++ b/native/morpho-close/src/morpho_close_gray_fast_r3.zig
@@ -1,0 +1,337 @@
+const abi = @import("morpho_close_abi.zig");
+const testing = @import("std").testing;
+
+const usize_max: usize = ~@as(usize, 0);
+
+// The queue is deliberately fixed-size.  Its capacity is also the largest
+// horizontal span accepted by the fast path, so all storage is known before
+// either destination is touched.
+const queue_capacity: usize = 1 << 15;
+const queue_mask: usize = queue_capacity - 1;
+const max_radius: usize = (queue_capacity - 1) / 2;
+const max_rows: usize = 1024;
+const max_taps: usize = 65536;
+const max_width: usize = 1 << 22;
+const max_height: usize = 1 << 20;
+
+const RowSpec = struct {
+    dy: i32,
+    radius: usize,
+};
+
+const QueueEntry = struct {
+    sequence: usize,
+    value: u8,
+};
+
+const SlidingQueue = struct {
+    entries: [queue_capacity]QueueEntry,
+    head: usize,
+    length: usize,
+
+    fn reset(self: *SlidingQueue) void {
+        self.head = 0;
+        self.length = 0;
+    }
+
+    fn slot(self: *const SlidingQueue, offset: usize) usize {
+        return (self.head + offset) & queue_mask;
+    }
+
+    fn front(self: *const SlidingQueue) QueueEntry {
+        return self.entries[self.head];
+    }
+
+    fn back(self: *const SlidingQueue) QueueEntry {
+        return self.entries[self.slot(self.length - 1)];
+    }
+
+    fn popFront(self: *SlidingQueue) void {
+        self.head = (self.head + 1) & queue_mask;
+        self.length -= 1;
+    }
+
+    fn popBack(self: *SlidingQueue) void {
+        self.length -= 1;
+    }
+
+    fn pushBack(self: *SlidingQueue, entry: QueueEntry) void {
+        // Preflight proves that a complete source window fits in the queue.
+        // The monotonic queue can never contain more entries than that window.
+        if (self.length == queue_capacity) unreachable;
+        self.entries[self.slot(self.length)] = entry;
+        self.length += 1;
+    }
+
+    fn pushMax(self: *SlidingQueue, sequence: usize, value: u8) void {
+        while (self.length != 0 and self.back().value <= value) {
+            self.popBack();
+        }
+        self.pushBack(.{ .sequence = sequence, .value = value });
+    }
+
+    fn pushMin(self: *SlidingQueue, sequence: usize, value: u8) void {
+        while (self.length != 0 and self.back().value >= value) {
+            self.popBack();
+        }
+        self.pushBack(.{ .sequence = sequence, .value = value });
+    }
+};
+
+const Reduce = enum { max, min };
+
+fn checkedShiftedRow(y: usize, dy: i32, height: usize) ?usize {
+    const signed_y: i64 = @intCast(y);
+    const signed_dy: i64 = @intCast(dy);
+    const shifted = signed_y + signed_dy;
+    if (shifted < 0 or shifted >= @as(i64, @intCast(height))) return null;
+    return @intCast(shifted);
+}
+
+fn extendedSample(
+    source: [*]const u8,
+    source_row: usize,
+    width: usize,
+    radius: usize,
+    sequence: usize,
+    outside: u8,
+) u8 {
+    const signed_sequence: i64 = @intCast(sequence);
+    const signed_radius: i64 = @intCast(radius);
+    const source_x = signed_sequence - signed_radius;
+    if (source_x < 0 or source_x >= @as(i64, @intCast(width))) return outside;
+    return source[source_row + @as(usize, @intCast(source_x))];
+}
+
+fn combine(destination: [*]u8, index: usize, candidate: u8, reduce: Reduce) void {
+    switch (reduce) {
+        .max => {
+            if (candidate > destination[index]) destination[index] = candidate;
+        },
+        .min => {
+            if (candidate < destination[index]) destination[index] = candidate;
+        },
+    }
+}
+
+fn horizontalSpan(
+    source: [*]const u8,
+    source_row: usize,
+    destination: [*]u8,
+    destination_row: usize,
+    width: usize,
+    radius: usize,
+    outside: u8,
+    reduce: Reduce,
+    queue: *SlidingQueue,
+) void {
+    const window_length = radius * 2 + 1;
+    queue.reset();
+
+    var sequence: usize = 0;
+    while (sequence < window_length) : (sequence += 1) {
+        const value = extendedSample(source, source_row, width, radius, sequence, outside);
+        switch (reduce) {
+            .max => queue.pushMax(sequence, value),
+            .min => queue.pushMin(sequence, value),
+        }
+    }
+
+    var x: usize = 0;
+    while (x < width) : (x += 1) {
+        if (x != 0) {
+            while (queue.length != 0 and queue.front().sequence < x) queue.popFront();
+
+            const incoming_sequence = x + window_length - 1;
+            const value = extendedSample(
+                source,
+                source_row,
+                width,
+                radius,
+                incoming_sequence,
+                outside,
+            );
+            switch (reduce) {
+                .max => queue.pushMax(incoming_sequence, value),
+                .min => queue.pushMin(incoming_sequence, value),
+            }
+        }
+
+        combine(destination, destination_row + x, queue.front().value, reduce);
+    }
+}
+
+fn runStage(
+    source: [*]const u8,
+    destination: [*]u8,
+    width: usize,
+    height: usize,
+    rows: *const [max_rows]RowSpec,
+    row_count: usize,
+    outside: u8,
+    reduce: Reduce,
+    queue: *SlidingQueue,
+) void {
+    var y: usize = 0;
+    while (y < height) : (y += 1) {
+        const destination_row = y * width;
+        var x: usize = 0;
+        while (x < width) : (x += 1) {
+            destination[destination_row + x] = outside;
+        }
+
+        var row_index: usize = 0;
+        while (row_index < row_count) : (row_index += 1) {
+            const row = rows.*[row_index];
+            const source_y = checkedShiftedRow(y, row.dy, height) orelse continue;
+            const source_row = source_y * width;
+            horizontalSpan(
+                source,
+                source_row,
+                destination,
+                destination_row,
+                width,
+                row.radius,
+                outside,
+                reduce,
+                queue,
+            );
+        }
+    }
+}
+
+fn preflight(
+    width: usize,
+    height: usize,
+    taps: [*]const abi.Tap,
+    taps_len: usize,
+    rows: *[max_rows]RowSpec,
+) ?usize {
+    if (width == 0 or height == 0 or taps_len == 0) return null;
+    if (width > max_width or height > max_height) return null;
+    if (width > usize_max / height) return null;
+    if (taps_len > max_taps) return null;
+    if (taps_len > usize_max / @sizeOf(abi.Tap)) return null;
+
+    var tap_index: usize = 0;
+    var row_count: usize = 0;
+    var previous_dy: i32 = 0;
+    var have_previous_dy = false;
+
+    while (tap_index < taps_len) {
+        if (row_count == max_rows) return null;
+
+        const row_start = tap_index;
+        const row_dy = taps[row_start].dy;
+        if (have_previous_dy and row_dy <= previous_dy) return null;
+        previous_dy = row_dy;
+        have_previous_dy = true;
+
+        const first_dx: i64 = @intCast(taps[row_start].dx);
+        if (first_dx > 0) return null;
+        const radius_i64 = -first_dx;
+        const radius: usize = @intCast(radius_i64);
+        if (radius > max_radius) return null;
+        if (radius > (usize_max - width) / 2) return null;
+        const span = radius * 2 + 1;
+
+        var offset: usize = 0;
+        while (tap_index < taps_len and taps[tap_index].dy == row_dy) {
+            if (offset >= span) return null;
+            const expected_dx: i64 = -radius_i64 + @as(i64, @intCast(offset));
+            const tap = taps[tap_index];
+            if (tap.weight != 255) return null;
+            if (@as(i64, @intCast(tap.dx)) != expected_dx) return null;
+            tap_index += 1;
+            offset += 1;
+        }
+
+        if (offset != span) return null;
+        rows[row_count] = .{ .dy = row_dy, .radius = radius };
+        row_count += 1;
+    }
+
+    return row_count;
+}
+
+pub fn tryClose(
+    input: [*]const u8,
+    dilated: [*]u8,
+    output: [*]u8,
+    width: usize,
+    height: usize,
+    taps: [*]const abi.Tap,
+    taps_len: usize,
+) bool {
+    var rows: [max_rows]RowSpec = undefined;
+    const row_count = preflight(width, height, taps, taps_len, &rows) orelse return false;
+
+    var queue: SlidingQueue = undefined;
+    queue.reset();
+
+    runStage(input, dilated, width, height, &rows, row_count, 0, .max, &queue);
+    runStage(dilated, output, width, height, &rows, row_count, 255, .min, &queue);
+    return true;
+}
+
+test "eligible gray row spans preserve border and gray values" {
+    const input = [_]u8{
+        1,  2,  3,  4,  5,
+        6,  7,  8,  9,  10,
+        11, 12, 13, 14, 15,
+    };
+    const taps = [_]abi.Tap{
+        .{ .dy = -1, .dx = 0, .weight = 255 },
+        .{ .dy = 0, .dx = -1, .weight = 255 },
+        .{ .dy = 0, .dx = 0, .weight = 255 },
+        .{ .dy = 0, .dx = 1, .weight = 255 },
+        .{ .dy = 1, .dx = 0, .weight = 255 },
+    };
+    const expected_dilated = [_]u8{
+        6,  7,  8,  9,  10,
+        11, 12, 13, 14, 15,
+        12, 13, 14, 15, 15,
+    };
+    const expected_output = [_]u8{
+        6,  6,  7,  8,  9,
+        6,  7,  8,  9,  10,
+        11, 12, 13, 14, 15,
+    };
+    var dilated = [_]u8{0xaa} ** input.len;
+    var output = [_]u8{0x55} ** input.len;
+
+    try testing.expect(tryClose(
+        input[0..].ptr,
+        dilated[0..].ptr,
+        output[0..].ptr,
+        5,
+        3,
+        taps[0..].ptr,
+        taps.len,
+    ));
+    try testing.expectEqualSlices(u8, expected_dilated[0..], dilated[0..]);
+    try testing.expectEqualSlices(u8, expected_output[0..], output[0..]);
+}
+
+test "ineligible row span leaves destinations untouched" {
+    const input = [_]u8{ 17, 128, 241, 33 };
+    const input_before = input;
+    const taps = [_]abi.Tap{.{ .dy = 0, .dx = 0, .weight = 0 }};
+    var dilated = [_]u8{0xa5} ** input.len;
+    const dilated_before = dilated;
+    var output = [_]u8{0x5a} ** input.len;
+    const output_before = output;
+
+    try testing.expect(!tryClose(
+        input[0..].ptr,
+        dilated[0..].ptr,
+        output[0..].ptr,
+        4,
+        1,
+        taps[0..].ptr,
+        taps.len,
+    ));
+    try testing.expectEqualSlices(u8, input_before[0..], input[0..]);
+    try testing.expectEqualSlices(u8, dilated_before[0..], dilated[0..]);
+    try testing.expectEqualSlices(u8, output_before[0..], output[0..]);
+}

--- a/native/morpho-close/src/morpho_close_test.zig
+++ b/native/morpho-close/src/morpho_close_test.zig
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+// with this package; see README.md and NOTICE for the source-offer notice.
+
+const std = @import("std");
+const abi = @import("morpho_close_abi.zig");
+const candidate = @import("morpho_close_fast_candidate_r1.zig");
+const library = @import("library.zig");
+const protocol = @import("protocol.zig");
+
+test "public C ABI has the frozen status values and validates lengths" {
+    const close: abi.CloseFn = library.musicspace_morpho_close_v1;
+    try std.testing.expectEqual(@as(u32, 0), @intFromEnum(abi.Status.ok));
+    try std.testing.expectEqual(@as(u32, 12), @intFromEnum(abi.Status.arithmetic_overflow));
+
+    var input = [_]u8{ 1, 2, 3, 4 };
+    var scratch = [_]u8{ 0xa5, 0xa5, 0xa5, 0xa5 };
+    var output = [_]u8{ 0x5a, 0x5a, 0x5a, 0x5a };
+    const taps = [_]abi.Tap{.{ .dy = 0, .dx = 0, .weight = 0 }};
+
+    const status = close(
+        input[0..].ptr,
+        input.len - 1,
+        scratch[0..].ptr,
+        scratch.len,
+        output[0..].ptr,
+        output.len,
+        2,
+        2,
+        taps[0..].ptr,
+        taps.len,
+    );
+    try std.testing.expectEqual(abi.Status.wrong_input_length, status);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xa5, 0xa5, 0xa5, 0xa5 }, scratch[0..]);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x5a, 0x5a, 0x5a, 0x5a }, output[0..]);
+}
+
+test "binary fast path preserves a center tap across a word boundary" {
+    var input = [_]u8{0} ** 140;
+    for (input[0..], 0..) |*value, index| {
+        value.* = if ((index % 5) == 0) 255 else 0;
+    }
+    var scratch = [_]u8{0xcc} ** 140;
+    var output = [_]u8{0x33} ** 140;
+    const taps = [_]abi.Tap{.{ .dy = 0, .dx = 0, .weight = 255 }};
+
+    try std.testing.expect(candidate.fastPathEligible(input[0..], 70, 2, taps[0..]));
+    const status = library.musicspace_morpho_close_v1(
+        input[0..].ptr,
+        input.len,
+        scratch[0..].ptr,
+        scratch.len,
+        output[0..].ptr,
+        output.len,
+        70,
+        2,
+        taps[0..].ptr,
+        taps.len,
+    );
+    try std.testing.expectEqual(abi.Status.ok, status);
+    try std.testing.expectEqualSlices(u8, input[0..], output[0..]);
+}
+
+test "generic gray path keeps the center sample exact" {
+    const input = [_]u8{ 10, 20, 30, 40 };
+    var scratch = [_]u8{0} ** 4;
+    var output = [_]u8{0} ** 4;
+    const taps = [_]abi.Tap{.{ .dy = 0, .dx = 0, .weight = 0 }};
+
+    try std.testing.expect(!candidate.fastPathEligible(input[0..], 2, 2, taps[0..]));
+    const status = library.closeInto(
+        input[0..].ptr,
+        input.len,
+        scratch[0..].ptr,
+        scratch.len,
+        output[0..].ptr,
+        output.len,
+        2,
+        2,
+        taps[0..].ptr,
+        taps.len,
+    );
+    try std.testing.expectEqual(abi.Status.ok, status);
+    try std.testing.expectEqualSlices(u8, input[0..], output[0..]);
+}
+
+test "probe decoder reads signed little-endian triples" {
+    const bytes = [_]u8{
+        0x01, 0x00, 0x00, 0x00,
+        0xfe, 0xff, 0xff, 0xff,
+        0xff, 0x00, 0x00, 0x00,
+        0xfd, 0xff, 0xff, 0xff,
+        0x04, 0x00, 0x00, 0x00,
+        0xfb, 0xff, 0xff, 0xff,
+    };
+    const taps = try protocol.decodeProbe(std.testing.allocator, bytes[0..]);
+    defer std.testing.allocator.free(taps);
+
+    try std.testing.expectEqual(@as(usize, 2), taps.len);
+    try std.testing.expectEqual(abi.Tap{ .dy = 1, .dx = -2, .weight = 255 }, taps[0]);
+    try std.testing.expectEqual(abi.Tap{ .dy = -3, .dx = 4, .weight = -5 }, taps[1]);
+}
+
+test "probe decoder rejects empty and non-record-aligned input" {
+    try std.testing.expectError(error.EmptyProbe, protocol.decodeProbe(std.testing.allocator, &[_]u8{}));
+    try std.testing.expectError(error.WrongProbeLength, protocol.decodeProbe(std.testing.allocator, &[_]u8{ 0, 1, 2 }));
+}

--- a/native/morpho-close/src/protocol.zig
+++ b/native/morpho-close/src/protocol.zig
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+// with this package; see README.md and NOTICE for the source-offer notice.
+
+const std = @import("std");
+const abi = @import("morpho_close_abi.zig");
+
+pub const probe_record_size: usize = 12;
+
+pub const DecodeError = error{
+    EmptyProbe,
+    WrongProbeLength,
+};
+
+fn readI32LittleEndian(bytes: []const u8, offset: usize) i32 {
+    const bits: u32 =
+        @as(u32, bytes[offset]) |
+        (@as(u32, bytes[offset + 1]) << 8) |
+        (@as(u32, bytes[offset + 2]) << 16) |
+        (@as(u32, bytes[offset + 3]) << 24);
+    return @bitCast(bits);
+}
+
+pub fn decodeProbe(allocator: std.mem.Allocator, bytes: []const u8) (DecodeError || std.mem.Allocator.Error)![]abi.Tap {
+    if (bytes.len == 0) return error.EmptyProbe;
+    if (bytes.len % probe_record_size != 0) return error.WrongProbeLength;
+
+    const taps = try allocator.alloc(abi.Tap, bytes.len / probe_record_size);
+    for (taps, 0..) |*tap, index| {
+        const offset = index * probe_record_size;
+        tap.* = .{
+            .dy = readI32LittleEndian(bytes, offset),
+            .dx = readI32LittleEndian(bytes, offset + 4),
+            .weight = readI32LittleEndian(bytes, offset + 8),
+        };
+    }
+    return taps;
+}

--- a/native/morpho-close/src/worker.zig
+++ b/native/morpho-close/src/worker.zig
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Isolated Audiveris morphology worker v1. Corresponding Source is supplied
+// with this package; see README.md and NOTICE for the source-offer notice.
+
+const std = @import("std");
+const abi = @import("morpho_close_abi.zig");
+const library = @import("library.zig");
+const protocol = @import("protocol.zig");
+
+const Io = std.Io;
+const usize_max: usize = ~@as(usize, 0);
+
+const Cli = struct {
+    width: usize,
+    height: usize,
+    input_path: []const u8,
+    probe_path: []const u8,
+    output_path: []const u8,
+};
+
+fn reportStatus(status: abi.Status, detail: []const u8) void {
+    std.debug.print("status={s} code={d} {s}\n", .{ @tagName(status), @intFromEnum(status), detail });
+}
+
+fn fail(status: abi.Status, detail: []const u8) noreturn {
+    reportStatus(status, detail);
+    std.process.exit(1);
+}
+
+fn parseUnsigned(text: []const u8) ?usize {
+    if (text.len == 0) return null;
+    return std.fmt.parseInt(usize, text, 10) catch null;
+}
+
+fn parseCli(args: []const []const u8) ?Cli {
+    if (args.len != 12) return null;
+    if (!std.mem.eql(u8, args[1], "close")) return null;
+    if (!std.mem.eql(u8, args[2], "--width")) return null;
+    if (!std.mem.eql(u8, args[4], "--height")) return null;
+    if (!std.mem.eql(u8, args[6], "--input")) return null;
+    if (!std.mem.eql(u8, args[8], "--probe")) return null;
+    if (!std.mem.eql(u8, args[10], "--output")) return null;
+
+    const width = parseUnsigned(args[3]) orelse return null;
+    const height = parseUnsigned(args[5]) orelse return null;
+    if (args[7].len == 0 or args[9].len == 0 or args[11].len == 0) return null;
+
+    return .{
+        .width = width,
+        .height = height,
+        .input_path = args[7],
+        .probe_path = args[9],
+        .output_path = args[11],
+    };
+}
+
+fn readFailureStatus(err: anyerror) abi.Status {
+    if (std.mem.eql(u8, @errorName(err), "FileTooBig") or
+        std.mem.eql(u8, @errorName(err), "StreamTooLong")) return .wrong_input_length;
+    return .arithmetic_overflow;
+}
+
+fn writeOutputAtomically(io: Io, allocator: std.mem.Allocator, output_path: []const u8, bytes: []const u8) abi.Status {
+    const temp_path = std.fmt.allocPrint(allocator, "{s}.part", .{output_path}) catch {
+        return .arithmetic_overflow;
+    };
+
+    const cwd = Io.Dir.cwd();
+    var temp_exists = false;
+    defer if (temp_exists) cwd.deleteFile(io, temp_path) catch {};
+
+    var file = cwd.createFile(io, temp_path, .{ .exclusive = true, .truncate = true }) catch |err| {
+        std.debug.print("create={s}\n", .{@errorName(err)});
+        return .arithmetic_overflow;
+    };
+    temp_exists = true;
+    defer file.close(io);
+
+    file.writeStreamingAll(io, bytes) catch |err| {
+        std.debug.print("write={s}\n", .{@errorName(err)});
+        return .arithmetic_overflow;
+    };
+
+    cwd.rename(temp_path, cwd, output_path, io) catch |err| {
+        std.debug.print("rename={s}\n", .{@errorName(err)});
+        return .arithmetic_overflow;
+    };
+    temp_exists = false;
+    return .ok;
+}
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.arena.allocator();
+
+    const args = init.minimal.args.toSlice(allocator) catch {
+        fail(.arithmetic_overflow, "argument allocation failed");
+    };
+
+    const cli = parseCli(args) orelse {
+        fail(.dimension_overflow, "usage: close --width W --height H --input INPUT.raw --probe PROBE.bin --output OUTPUT.raw");
+    };
+
+    if (cli.width == 0) {
+        fail(.zero_width, "width must be nonzero");
+    }
+    if (cli.height == 0) {
+        fail(.zero_height, "height must be nonzero");
+    }
+    if (cli.width > usize_max / cli.height) {
+        fail(.dimension_overflow, "width*height overflows size_t");
+    }
+
+    const pixel_count = cli.width * cli.height;
+    const input_limit: Io.Limit = if (pixel_count == usize_max)
+        .unlimited
+    else
+        .limited(pixel_count + 1);
+    const cwd = Io.Dir.cwd();
+
+    const input_bytes = cwd.readFileAlloc(init.io, cli.input_path, allocator, input_limit) catch |err| {
+        fail(readFailureStatus(err), "input read failed");
+    };
+    if (input_bytes.len != pixel_count) {
+        fail(.wrong_input_length, "input length does not equal width*height");
+    }
+
+    const probe_bytes = cwd.readFileAlloc(init.io, cli.probe_path, allocator, .unlimited) catch |err| {
+        fail(readFailureStatus(err), "probe read failed");
+    };
+    const taps = protocol.decodeProbe(allocator, probe_bytes) catch |err| {
+        const status: abi.Status = switch (err) {
+            error.EmptyProbe => .zero_taps,
+            error.WrongProbeLength => .wrong_input_length,
+            else => .arithmetic_overflow,
+        };
+        fail(status, "probe must contain nonempty little-endian i32 triples");
+    };
+
+    const scratch = allocator.alloc(u8, pixel_count) catch {
+        fail(.arithmetic_overflow, "scratch allocation failed");
+    };
+    const output = allocator.alloc(u8, pixel_count) catch {
+        fail(.arithmetic_overflow, "output allocation failed");
+    };
+
+    const status = library.closeInto(
+        input_bytes.ptr,
+        input_bytes.len,
+        scratch.ptr,
+        scratch.len,
+        output.ptr,
+        output.len,
+        cli.width,
+        cli.height,
+        taps.ptr,
+        taps.len,
+    );
+    if (status != .ok) {
+        fail(status, "morphology failed");
+    }
+
+    const write_status = writeOutputAtomically(init.io, allocator, cli.output_path, output);
+    if (write_status != .ok) {
+        fail(write_status, "output write failed");
+    }
+    reportStatus(.ok, "close complete");
+}


### PR DESCRIPTION
## Summary

This draft adds an optional Zig 0.16 CPU accelerator for
`MorphoProcessor.close` and a Java 25 Foreign Function and Memory bridge.
The native path is disabled unless an explicit shared-library path is supplied.
If loading or execution fails, Audiveris uses the existing Java implementation.

The hot path uses one in-process C ABI call per grayscale plane. It does not
spawn a helper process and does not exchange temporary files.

## Source layout

- `native/morpho-close/`: complete AGPL-3.0-only Zig source, tests, C header,
  protocol notes, build instructions and benchmark boundaries;
- `MorphoProcessor.java`: optional Java 25 FFM integration, reusable native
  buffers, circuit breaker, counters and the unchanged Java fallback.

## Verification performed

- `zig fmt --check build.zig src`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- clean Java 25 Gradle build and install distribution
- 22 successful stock/native sheet pairs with exact extracted score XML after
  replacing only the volatile `encoding-date`
- 3 additional inputs with matching early rejection/export-failure behavior

Raw MXL archives are not claimed to be byte-identical because containers may
include volatile metadata.

## Measured result

Measurements were made on Apple Silicon macOS with identical Audiveris builds,
input bytes and batch settings.

- additional 20-sheet corpus: 22.544% lower total wall time across 17
  successful exports (216.73 s stock, 167.87 s native);
- initial five-sheet set: 28.954% to 38.298% improvement;
- Pirate warm p50: 22.876 s stock, 14.543 s native;
- largest observed per-sheet improvement: 42.430%.

These results are not a cross-platform guarantee. The optional path and its
limitations are documented in `native/morpho-close/BENCHMARKS.md`.

## Review requested

This is intentionally a draft. Feedback is especially welcome on:

- whether the optional module belongs at this repository location;
- the Java 25 FFM boundary and opt-in property;
- platform/build integration expectations before the change could be enabled
  outside the measured Apple Silicon environment.
