### PR TITLE
Fix non-transitive comparator in StemBuilder.sortItems (latent TimSort crash)

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/stem/StemBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/stem/StemBuilder.java
@@ -73,6 +73,7 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1151,24 +1152,47 @@ public class StemBuilder
      */
     private void sortItems (List<? extends StemItem> list)
     {
-        Collections.sort(
-                list,
-                (se1,
-                 se2) -> {
-                    // Linker pairs are sorted on their refPt ordinate
-                    if (se1 instanceof HalfLinkerItem hl1) {
-                        if (se2 instanceof HalfLinkerItem hl2) {
-                            final Point2D p1 = hl1.linker.getReferencePoint();
-                            final Point2D p2 = hl2.linker.getReferencePoint();
-                            return yDir * Double.compare(p1.getY(), p2.getY());
-                        }
-                    }
+        Collections.sort(list, ordinateComparator(yDir));
+    }
 
-                    // Others are sorted on their line starting ordinate
-                    return (yDir > 0) //
-                            ? Double.compare(se1.line.getY1(), se2.line.getY1())
-                            : Double.compare(se2.line.getY2(), se1.line.getY2());
-                });
+    //--------------------//
+    // ordinateComparator //
+    //--------------------//
+    /**
+     * Report the comparator used to sort stem items along the provided yDir.
+     * <p>
+     * Each item is compared via a single ordinate key, whatever the other item in the pair,
+     * so that the comparator is transitive as required by the sorting contract.
+     *
+     * @param yDir the desired vertical direction
+     * @return the item comparator
+     */
+    static Comparator<StemItem> ordinateComparator (int yDir)
+    {
+        return (se1,
+                se2) -> yDir * Double.compare(ordinateKeyOf(se1, yDir), ordinateKeyOf(se2, yDir));
+    }
+
+    //---------------//
+    // ordinateKeyOf //
+    //---------------//
+    /**
+     * Report the ordinate key used to sort the provided item along yDir.
+     *
+     * @param item the item to evaluate
+     * @param yDir the desired vertical direction
+     * @return the item sorting ordinate
+     */
+    private static double ordinateKeyOf (StemItem item,
+                                         int yDir)
+    {
+        // A half linker item is located on its refPt ordinate
+        if (item instanceof HalfLinkerItem hl) {
+            return hl.linker.getReferencePoint().getY();
+        }
+
+        // Others are located on their line starting ordinate (line is oriented top down)
+        return (yDir > 0) ? item.line.getY1() : item.line.getY2();
     }
 
     //----------//

--- a/app/src/test/java/org/audiveris/omr/sheet/stem/StemItemSortTest.java
+++ b/app/src/test/java/org/audiveris/omr/sheet/stem/StemItemSortTest.java
@@ -1,0 +1,233 @@
+//------------------------------------------------------------------------------------------------//
+//                                                                                                //
+//                                 S t e m I t e m S o r t T e s t                                //
+//                                                                                                //
+//------------------------------------------------------------------------------------------------//
+package org.audiveris.omr.sheet.stem;
+
+import org.audiveris.omr.glyph.Glyph;
+import org.audiveris.omr.run.Orientation;
+import org.audiveris.omr.run.RunTable;
+import org.audiveris.omr.sheet.stem.StemItem.GapItem;
+import org.audiveris.omr.sheet.stem.StemItem.HalfLinkerItem;
+import org.audiveris.omr.sig.inter.Inter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+import java.awt.geom.Area;
+import java.awt.geom.Line2D;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Tests for the ordinate sorting of {@link StemItem} instances in {@link StemBuilder}.
+ * <p>
+ * The former comparator was pair-dependent: two {@link HalfLinkerItem}s compared on their
+ * linker reference-point ordinate, while every other pair compared on line endpoints.
+ * Such a comparator is not transitive; TimSort can detect this at merge time and throw
+ * <code>IllegalArgumentException: "Comparison method violates its general contract!"</code>.
+ * (Lists shorter than TimSort's MIN_MERGE of 32 elements are sorted via binary insertion,
+ * which never checks the contract, so real crashes require larger item lists.)
+ */
+public class StemItemSortTest
+{
+    //~ Methods ------------------------------------------------------------------------------------
+
+    /**
+     * Demonstrate the former crash: the pair-dependent comparator, applied to a 40-item
+     * list of plausible stem items, makes TimSort detect the contract violation and throw.
+     */
+    @Test
+    public void formerComparatorCrashesTimSort ()
+    {
+        final List<StemItem> items = buildAdversarialItems(21, 40);
+
+        try {
+            Collections.sort(items, formerComparator(1));
+            fail("Former pair-dependent comparator should violate the sorting contract");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Comparison method violates its general contract!", ex.getMessage());
+        }
+    }
+
+    /**
+     * The fixed comparator sorts the very same adversarial list, in both directions and
+     * under many input permutations, and the result is pairwise consistent.
+     */
+    @Test
+    public void ordinateComparatorSortsAdversarialList ()
+    {
+        for (int yDir : new int[] { 1, -1 }) {
+            final Comparator<StemItem> comparator = StemBuilder.ordinateComparator(yDir);
+            final Random rnd = new Random(4285);
+
+            for (int shuffle = 0; shuffle < 100; shuffle++) {
+                final List<StemItem> items = buildAdversarialItems(21, 40);
+                Collections.shuffle(items, rnd);
+
+                Collections.sort(items, comparator); // Must not throw
+
+                for (int i = 0; i < items.size(); i++) {
+                    for (int j = i + 1; j < items.size(); j++) {
+                        assertTrue(
+                                "Sorted order must be pairwise consistent",
+                                comparator.compare(items.get(i), items.get(j)) <= 0);
+                    }
+                }
+            }
+        }
+    }
+
+    //~ Helper methods -----------------------------------------------------------------------------
+
+    /** Deterministic mix of half-linker items (with stumps) and gap items. */
+    private static List<StemItem> buildAdversarialItems (long seed,
+                                                         int n)
+    {
+        final Random rnd = new Random(seed);
+        final List<StemItem> items = new ArrayList<>();
+
+        for (int i = 0; i < n; i++) {
+            if (rnd.nextBoolean()) {
+                final double refY = rnd.nextInt(1000);
+                final int stumpTop = rnd.nextInt(1000);
+                items.add(
+                        new HalfLinkerItem(
+                                new FakeHalfLinker(refY, makeStump(100, stumpTop, 10)),
+                                10));
+            } else {
+                final int y1 = rnd.nextInt(1000);
+                items.add(new GapItem(new Line2D.Double(50, y1, 50, y1 + 10 + rnd.nextInt(20))));
+            }
+        }
+
+        return items;
+    }
+
+    /** The pair-dependent comparator formerly used by StemBuilder.sortItems, copied verbatim. */
+    private static Comparator<StemItem> formerComparator (int yDir)
+    {
+        return (se1,
+                se2) ->
+        {
+            // Linker pairs are sorted on their refPt ordinate
+            if (se1 instanceof HalfLinkerItem hl1) {
+                if (se2 instanceof HalfLinkerItem hl2) {
+                    final Point2D p1 = hl1.linker.getReferencePoint();
+                    final Point2D p2 = hl2.linker.getReferencePoint();
+                    return yDir * Double.compare(p1.getY(), p2.getY());
+                }
+            }
+
+            // Others are sorted on their line starting ordinate
+            return (yDir > 0) //
+                    ? Double.compare(se1.line.getY1(), se2.line.getY1())
+                    : Double.compare(se2.line.getY2(), se1.line.getY2());
+        };
+    }
+
+    /** Build a small vertical stump glyph whose center line starts at the provided top. */
+    private static Glyph makeStump (int left,
+                                    int top,
+                                    int height)
+    {
+        final RunTable table = new RunTable(Orientation.VERTICAL, 1, height);
+        table.addRun(0, 0, height);
+
+        return new Glyph(left, top, table);
+    }
+
+    //~ Inner classes ------------------------------------------------------------------------------
+
+    /**
+     * Minimal half linker: its reference point ordinate and its stump geometry are
+     * chosen independently, exactly like a CLinker/VLinker whose stump center line
+     * does not start at the reference point.
+     */
+    private static class FakeHalfLinker
+            extends StemHalfLinker
+    {
+        private final Point2D refPt;
+
+        private final Glyph stump;
+
+        FakeHalfLinker (double refY,
+                        Glyph stump)
+        {
+            this.refPt = new Point2D.Double(100, refY);
+            this.stump = stump;
+        }
+
+        @Override
+        public Collection<? extends StemHalfLinker> getHalfLinkers ()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getId ()
+        {
+            return "fake-" + refPt.getY();
+        }
+
+        @Override
+        public Area getLookupArea ()
+        {
+            return null;
+        }
+
+        @Override
+        public Point2D getReferencePoint ()
+        {
+            return refPt;
+        }
+
+        @Override
+        public Inter getSource ()
+        {
+            return null;
+        }
+
+        @Override
+        public Glyph getStump ()
+        {
+            return stump;
+        }
+
+        @Override
+        public Line2D getTheoreticalLine ()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isClosed ()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isLinked ()
+        {
+            return false;
+        }
+
+        @Override
+        public void setClosed (boolean closed)
+        {
+        }
+
+        @Override
+        public void setLinked (boolean linked)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The lambda comparator in `StemBuilder.sortItems` is pair-dependent: two `HalfLinkerItem`s compare on their linker **reference-point ordinate**, while every other pair — including a `HalfLinkerItem` mixed with any other item kind — compares on **line endpoints**. When a half linker's stump center line does not start at its reference point, the two rules can rank items inconsistently, so the comparator is not transitive and violates the `Comparator` contract.

Consequences:

- `java.util.TimSort` detects contract violations during merges and throws `IllegalArgumentException: "Comparison method violates its general contract!"` — a latent crash of the STEMS step for item lists of 32+ elements.
- Below that threshold (TimSort's `MIN_MERGE`), lists fall back to binary insertion sort, which never checks the contract — so on typical pages the item order is implementation-defined rather than data-defined, and may silently change with a JDK update.

This was found during an independent reimplementation effort that replays `StemBuilder` behavior exactly: an exhaustive audit over an eight-page corpus found 18 strict comparator cycles (including one four-item final item list) and 2,503 pairwise-equivalence inconsistencies.

## Crash demonstration

The included `StemItemSortTest.formerComparatorCrashesTimSort` builds a deterministic 40-item list of `HalfLinkerItem`s (with real `Glyph` stumps whose center line does not start at the linker reference point) mixed with `GapItem`s, and sorts it with the former comparator, copied verbatim:

```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.base/java.util.TimSort.mergeLo(TimSort.java:781)
	at java.base/java.util.TimSort.mergeAt(TimSort.java:518)
	at java.base/java.util.TimSort.mergeCollapse(TimSort.java:448)
	at java.base/java.util.TimSort.sort(TimSort.java:245)
	at java.base/java.util.Arrays.sort(Arrays.java:1308)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1804)
	at java.base/java.util.Collections.sort(Collections.java:178)
```

## Fix

Compare every item via a single, context-independent ordinate key, via a package-private static `ordinateComparator(int yDir)` factory (exposed for the test):

- `HalfLinkerItem` → its linker reference-point ordinate (the documented intent: "Linker pairs are sorted on their refPt ordinate");
- all other items → their directional line start ordinate (`getY1()` for `yDir > 0`, `getY2()` for `yDir < 0`), as before.

A single scalar key makes the comparator a total preorder, hence transitive by construction. Ordering within same-kind pairs is unchanged (both branches reduce to exactly the previous comparisons, including the reversed `getY2()` comparison for `yDir < 0`); only mixed pairs — precisely the pairs that previously had no self-consistent ordering — are affected.

## Validation

- `StemItemSortTest` passes: the former comparator throws on the adversarial list; the fixed comparator sorts it consistently in both directions under 100 random permutations.
- `:app:compileJava` and the new tests pass on this branch.

---
_Generated by [Claude Code](https://claude.ai/code)_
