### PR TITLE
Fill every stem profile, not just up to maxStemProfile

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/stem/StemBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/stem/StemBuilder.java
@@ -1104,7 +1104,6 @@ public class StemBuilder
         }
 
         final TreeMap<Integer, Integer> gapMap = retriever.getGapMap();
-        final int maxGap = gapMap.get(maxStemProfile);
         final int maxIndex = items.size() - 1;
 
         for (int i = 0; i <= maxIndex; i++) {
@@ -1121,14 +1120,6 @@ public class StemBuilder
                     } else {
                         break;
                     }
-                }
-
-                if (ev.contrib > maxGap) {
-                    if (lengthMap.get(maxStemProfile) == null) {
-                        lengthMap.put(maxStemProfile, getLengthAt(i - 1));
-                    }
-
-                    return;
                 }
             }
         }


### PR DESCRIPTION
Fixes #696

A stem retried at a higher profile stops throwing.

`retrieveLengths` stops as soon as it hits a gap bigger than the one allowed at `maxStemProfile`, so profiles above that never get into `lengthMap`. `linkSides` does retry at a higher profile, and `getLength` unboxes a null there.

Removing the early return lets the loop finish. The profiles below were already filled by then and the puts are null-guarded, so nothing else changes.

