### PR TITLE
Remove an inter's edges before its vertex

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sig/SIGraph.java
+++ b/app/src/main/java/org/audiveris/omr/sig/SIGraph.java
@@ -1346,6 +1346,14 @@ public class SIGraph
             logger.info("VIP removeVertex {}", inter);
         }
 
+        // A relation removal can cascade and take another edge of this vertex, which the
+        // inherited removeVertex does not expect: it snapshots the edge set up front.
+        for (Relation relation : new ArrayList<>(edgesOf(inter))) {
+            if (containsEdge(relation)) {
+                removeEdge(relation);
+            }
+        }
+
         return super.removeVertex(inter);
     }
 


### PR DESCRIPTION
Fixes #985

An inter whose removal cascades no longer aborts the step.

`SigListener.edgeRemoved` lets a relation remove further inters, which can take another edge of the vertex being removed. `DefaultListenableGraph.removeVertex` copies the edge set first, so it then calls `getEdgeSource` on an edge that has gone.

Removing the touching edges first, skipping any already gone, leaves `super.removeVertex` an empty set.

