### PR TITLE
Open a book's zip by its path, not by a jar URI

### DIFF
--- a/app/src/main/java/org/audiveris/omr/util/ZipFileSystem.java
+++ b/app/src/main/java/org/audiveris/omr/util/ZipFileSystem.java
@@ -22,7 +22,6 @@
 package org.audiveris.omr.util;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -82,8 +81,7 @@ public abstract class ZipFileSystem
         final Map<String, String> env = new HashMap<>();
         env.put("create", "true");
 
-        final URI uri = URI.create("jar:" + path.toUri());
-        final FileSystem fs = FileSystems.newFileSystem(uri, env, null);
+        final FileSystem fs = FileSystems.newFileSystem(path, env);
 
         return fs.getPath(fs.getSeparator());
     }
@@ -107,8 +105,7 @@ public abstract class ZipFileSystem
         Objects.requireNonNull(path, "ZipFileSystem.open: path is null");
 
         final Map<String, String> env = new HashMap<>(); // Empty map
-        final URI uri = URI.create("jar:" + path.toUri());
-        final FileSystem fs = FileSystems.newFileSystem(uri, env, null);
+        final FileSystem fs = FileSystems.newFileSystem(path, env);
 
         return fs.getPath(fs.getSeparator());
     }


### PR DESCRIPTION
Fixes #988

A book under a folder ending in `!` is stored and reopened where it was asked for.

The `jar:` URI `ZipFileSystem` builds is read with the legacy jar URL syntax, which cuts the path at the first `!/` and takes the rest for an entry inside the archive. A book under a folder whose name ends in `!` is stored to the truncated path, and cannot be reopened.

Passing the path itself to `FileSystems.newFileSystem` reaches the same provider with no URI to parse, which is what `Book.openBookFile` already does. Nothing else changes: my scores come out identical.


