### PR TITLE
Pair a small staff's repeat dots by that staff's own interline

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sig/inter/RepeatDotInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/RepeatDotInter.java
@@ -128,13 +128,14 @@ public class RepeatDotInter
     public Rectangle getDotLuBox (SystemInfo system,
                                   int profile)
     {
-        final Scale scale = system.getSheet().getScale();
         final int dotPitch = getIntegerPitch();
         final Rectangle dotLuBox = getBounds();
 
+        // The staff's own interline: on a small staff the pair sits closer than the sheet's.
+        //
         // TODO: Perhaps we could grow dotLuBox based on profile level?
         //
-        dotLuBox.y -= (scale.getInterline() * dotPitch);
+        dotLuBox.y -= (staff.getSpecificInterline() * dotPitch);
 
         return dotLuBox;
     }


### PR DESCRIPTION
Fixes #992

A repeat on a small staff is read again.

`getDotLuBox` shifts the dot's box by one interline to find its sibling, and takes the sheet's main interline. Where the sheet's largest staff is not the music, a legend panel for instance, every music staff is small. Its dots then sit closer together than the sheet's interline. The box then reaches past the sibling, `checkRepeatPairs` finds no pair, and both dots are deleted.

The dot's own pitch is already measured against its staff, so the lookup that goes with it should be too. `getSpecificInterline()` is what the rest of the code uses for this.

Over the drum charts I have here it recovers some fifty repeats and moves nothing else.



