### PR TITLE
Read a repeat from the dots and keep the bar line group that opens a system

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/grid/BarsRetriever.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/grid/BarsRetriever.java
@@ -1224,6 +1224,7 @@ public class BarsRetriever
         for (SystemInfo system : sheet.getSystems()) {
             List<BarColumn> columns = columnMap.get(system);
             BarColumn startColumn = null; // Last full column (within same group as first full)
+            final List<BarColumn> startGroup = new ArrayList<>(); // Whole starting group
 
             for (int i = 0; i < columns.size(); i++) {
                 final BarColumn column = columns.get(i);
@@ -1241,6 +1242,7 @@ public class BarsRetriever
 
                     if (column.isFullyConnected()) {
                         startColumn = column;
+                        startGroup.add(column);
                     }
                 }
             }
@@ -1249,19 +1251,25 @@ public class BarsRetriever
                 logger.debug("{} candidate startColumn: {}", system, startColumn);
 
                 StaffPeak[] startPeaks = startColumn.getPeaks();
+                StaffPeak[] firstPeaks = startGroup.get(0).getPeaks();
 
-                for (StaffPeak peak : startPeaks) {
+                for (int ip = 0; ip < startPeaks.length; ip++) {
+                    final StaffPeak peak = startPeaks[ip];
                     final Staff staff = peak.getStaff();
 
                     if (!staff.isOneLineStaff()) {
                         int xLeft = staff.getAbscissa(LEFT); // Based on long line chunks only
 
-                        // Check column is not too far right into staff
-                        if ((peak.getStart() - xLeft) > params.maxLinesLeftToStartBar) {
-                            if (peak.isVip() || logger.isDebugEnabled()) {
+                        // Not too far right into staff, measured from the group's first
+                        // bar: the long line chunks begin inside the group, so its last
+                        // bar is always too far right.
+                        final StaffPeak first = firstPeaks[ip];
+
+                        if ((first.getStart() - xLeft) > params.maxLinesLeftToStartBar) {
+                            if (first.isVip() || logger.isDebugEnabled()) {
                                 logger.info(
                                         "start {} too far inside staff#{}",
-                                        peak,
+                                        first,
                                         staff.getId());
                             }
 
@@ -1284,11 +1292,17 @@ public class BarsRetriever
                     }
                 }
 
-                // Use start column as left limit
-                for (StaffPeak peak : startColumn.getPeaks()) {
-                    Staff staff = peak.getStaff();
-                    staff.setAbscissa(LEFT, peak.getStop());
-                    peak.setStaffEnd(LEFT);
+                // The whole group is the staff end, so purgeLeftPeaks keeps it.
+                for (BarColumn column : startGroup) {
+                    for (StaffPeak peak : column.getPeaks()) {
+                        peak.setStaffEnd(LEFT);
+                    }
+                }
+
+                // The staff starts inside the group's first bar, where retrieveSideBars
+                // looks for it and HeaderBuilder begins.
+                for (StaffPeak peak : startGroup.get(0).getPeaks()) {
+                    peak.getStaff().setAbscissa(LEFT, peak.getStop());
                 }
             } else if (system.isMultiStaff()) {
                 logger.warn("No startColumn found for multi-staff {}", system);

--- a/app/src/main/java/org/audiveris/omr/sig/inter/StaffBarlineInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/StaffBarlineInter.java
@@ -912,7 +912,8 @@ public final class StaffBarlineInter
 
             case 3 -> true; // Style should be LIGHT_HEAVY_LIGHT
 
-            default -> false;
+            // The dots spell the repeat; the bar count only decides thin against thick.
+            default -> size > 0;
         };
     }
 
@@ -960,7 +961,8 @@ public final class StaffBarlineInter
 
             case 3 -> true; // Style should be LIGHT_HEAVY_LIGHT
 
-            default -> false;
+            // The dots spell the repeat; the bar count only decides thin against thick.
+            default -> size > 0;
         };
     }
 


### PR DESCRIPTION
Fixes #995 , Fixes #994

A repeat drawn on one bar line is read, and a system opening on a group keeps the whole group.

Two commits, together because the second regresses on its own.

`isLeftRepeat` and `isRightRepeat` refuse a group of one bar and a group of more than three. The dots have settled it by then: paired, bound to the bar, checked for pitch. The bar count only decides thin against thick.

`detectStartColumns` measures the start column against the staff's left end, which comes from the long line chunks alone. Those begin inside a starting group, so the check is made across it rather than in front of it. Measured from the group's first bar it means what it was meant to.

Alone the second loses three repeats on one chart of my test corpus, where the opening group grows past three bars. Together they recover around thirty across the drum charts I have here and lose none. A few measure edges shift slightly at system openings, which is the change doing its job.


