### PR TITLE
Register a header clef only when it grades like one

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/clef/ClefBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/clef/ClefBuilder.java
@@ -217,10 +217,33 @@ public class ClefBuilder
             bestMap = getBestMap(false);
         }
 
-        // Register the remaining clef candidates
-        if (!bestMap.isEmpty()) {
+        // Register the remaining candidates, unless none of them is really a clef: the
+        // header is erased before symbols are read, so a clef found on the first note
+        // column of a staff that prints none takes that music with it.
+        if (!bestMap.isEmpty() && bestGrade(bestMap) >= constants.minRegisteredGrade
+                .getValue()) {
             registerClefs(bestMap.values());
         }
+    }
+
+    //-----------//
+    // bestGrade //
+    //-----------//
+    /**
+     * Report the best grade among the clef candidates.
+     *
+     * @param bestMap the candidate clefs, per kind
+     * @return the highest grade, 0 if there is none
+     */
+    private static double bestGrade (Map<ClefKind, ClefInter> bestMap)
+    {
+        double best = 0;
+
+        for (ClefInter clef : bestMap.values()) {
+            best = Math.max(best, clef.getGrade());
+        }
+
+        return best;
     }
 
     //------------//
@@ -732,6 +755,10 @@ public class ClefBuilder
                 "none",
                 3,
                 "Maximum acceptable rank in clef evaluation");
+
+        private final Constant.Ratio minRegisteredGrade = new Constant.Ratio(
+                0.65,
+                "Minimum grade for a staff header clef to be kept at all");
     }
 
     //------------//


### PR DESCRIPTION
Fixes #997

A staff that prints no clef stops getting one, and so stops having its opening erased.

The fallback pass in `findClefs` settles on the first note column when a staff prints no clef, and registers it whatever it grades. A real clef grades close to the 0.8 ceiling `intrinsicRatio` imposes. The invented ones never came near it, so registering only above `minRegisteredGrade`, at 0.65, separates them with room either side.

This goes at the cause, not the erasing: with no clef there is no header, so nothing is erased. Raising `Grades.clefMinGrade` instead makes the first pass fail more often, so the fallback runs more often and finds worse.

Over the drum charts I have here it drops some seventy clefs on nine of them and leaves the other two thousand alone. It moves no repeat on its own, since those are already lost to #992.

