### PR TITLE
Read repeat barline counts printed as xN or Nx

### DIFF
--- a/app/src/main/java/org/audiveris/omr/score/PartwiseBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/score/PartwiseBuilder.java
@@ -1281,6 +1281,14 @@ public class PartwiseBuilder
                             if (stack.isRepeat(RIGHT)) {
                                 Repeat repeat = factory.createRepeat();
                                 repeat.setDirection(BackwardForward.BACKWARD);
+
+                                // Number of passes, when printed such as "x4"
+                                final Integer count = partBarline.getRepeatCount();
+
+                                if (count != null) {
+                                    repeat.setTimes(BigInteger.valueOf(count));
+                                }
+
                                 pmBarline.setRepeat(repeat);
                             }
 

--- a/app/src/main/java/org/audiveris/omr/sheet/PartBarline.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/PartBarline.java
@@ -144,6 +144,27 @@ public class PartBarline
         return sb.getEnding(side);
     }
 
+    //----------------//
+    // getRepeatCount //
+    //----------------//
+    /**
+     * Report the number of passes printed for this barline, such as "x4".
+     *
+     * @return the repeat count, or null if none
+     */
+    public Integer getRepeatCount ()
+    {
+        for (StaffBarlineInter sb : staffBarlines) {
+            final Integer count = sb.getRepeatCount();
+
+            if (count != null) {
+                return count;
+            }
+        }
+
+        return null;
+    }
+
     //-------------//
     // getFermatas //
     //-------------//

--- a/app/src/main/java/org/audiveris/omr/sig/SigValue.java
+++ b/app/src/main/java/org/audiveris/omr/sig/SigValue.java
@@ -142,6 +142,7 @@ import org.audiveris.omr.sig.relation.NextInVoiceRelation;
 import org.audiveris.omr.sig.relation.NoExclusion;
 import org.audiveris.omr.sig.relation.OctaveShiftChordRelation;
 import org.audiveris.omr.sig.relation.Relation;
+import org.audiveris.omr.sig.relation.RepeatCountRelation;
 import org.audiveris.omr.sig.relation.RepeatDotBarRelation;
 import org.audiveris.omr.sig.relation.RepeatDotPairRelation;
 import org.audiveris.omr.sig.relation.SameTimeRelation;
@@ -450,6 +451,7 @@ public class SigValue
                 @XmlElementRef(type = NextInVoiceRelation.class),
                 @XmlElementRef(type = NoExclusion.class),
                 @XmlElementRef(type = OctaveShiftChordRelation.class),
+                @XmlElementRef(type = RepeatCountRelation.class),
                 @XmlElementRef(type = RepeatDotBarRelation.class),
                 @XmlElementRef(type = RepeatDotPairRelation.class),
                 @XmlElementRef(type = SameTimeRelation.class),

--- a/app/src/main/java/org/audiveris/omr/sig/inter/SentenceInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/SentenceInter.java
@@ -21,6 +21,7 @@
 // </editor-fold>
 package org.audiveris.omr.sig.inter;
 
+import org.audiveris.omr.constant.ConstantSet;
 import org.audiveris.omr.sheet.Scale;
 import org.audiveris.omr.sheet.Skew;
 import org.audiveris.omr.sheet.Staff;
@@ -33,6 +34,7 @@ import org.audiveris.omr.sig.relation.ChordSyllableRelation;
 import org.audiveris.omr.sig.relation.Containment;
 import org.audiveris.omr.sig.relation.EndingSentenceRelation;
 import org.audiveris.omr.sig.relation.Link;
+import org.audiveris.omr.sig.relation.RepeatCountRelation;
 import org.audiveris.omr.sig.ui.UITask;
 import org.audiveris.omr.text.FontInfo;
 import org.audiveris.omr.text.TextLine;
@@ -94,6 +96,8 @@ public class SentenceInter
         implements InterEnsemble
 {
     //~ Static fields/initializers -----------------------------------------------------------------
+
+    private static final Constants constants = new Constants();
 
     private static final Logger logger = LoggerFactory.getLogger(SentenceInter.class);
 
@@ -498,6 +502,18 @@ public class SentenceInter
                         sig.addEdge(link.partner, this, link.relation);
                     }
                 }
+
+                case RepeatCount -> {
+                    // Look for the right repeat barline this count applies to
+                    final Link link = lookupRepeatBarLink(system);
+
+                    if ((link != null) && (null == sig.getRelation(
+                            link.partner,
+                            this,
+                            RepeatCountRelation.class))) {
+                        sig.addEdge(link.partner, this, link.relation);
+                    }
+                }
             }
 
             // Roles UnknownRole, Title, Number, Creator*, Rights stand by themselves
@@ -530,6 +546,61 @@ public class SentenceInter
         }
 
         return null;
+    }
+
+    //---------------------//
+    // lookupRepeatBarLink //
+    //---------------------//
+    /**
+     * Try to detect the right repeat barline that this repeat count applies to.
+     * <p>
+     * The count is printed just above or just below the barline, so the search window is kept
+     * well below the vertical gap between two systems.
+     *
+     * @param system surrounding system
+     * @return detected link or null
+     */
+    public Link lookupRepeatBarLink (SystemInfo system)
+    {
+        final Scale scale = system.getSheet().getScale();
+        final int maxDx = scale.toPixels(constants.maxRepeatCountDx);
+        final int maxDy = scale.toPixels(constants.maxRepeatCountDy);
+        final Point2D textCenter = getCenter2D();
+
+        StaffBarlineInter bestBar = null;
+        double bestDx = Double.MAX_VALUE;
+
+        for (Inter inter : system.getSig().inters(StaffBarlineInter.class)) {
+            final StaffBarlineInter bar = (StaffBarlineInter) inter;
+
+            if (!bar.isRightRepeat()) {
+                continue;
+            }
+
+            final Rectangle barBox = bar.getBounds();
+            final double dx = Math.abs(textCenter.getX() - (barBox.x + (barBox.width / 2.0)));
+
+            if (dx > maxDx) {
+                continue;
+            }
+
+            final double dy = Math.max(
+                    0,
+                    Math.max(
+                            barBox.y - textCenter.getY(),
+                            textCenter.getY() - (barBox.y + barBox.height)));
+
+            if (dy > maxDy) {
+                continue;
+            }
+
+            if (dx < bestDx) {
+                bestDx = dx;
+                bestBar = bar;
+            }
+        }
+
+        return (bestBar != null) ? new Link(bestBar, new RepeatCountRelation(), false) : null;
     }
 
     //--------//
@@ -581,12 +652,16 @@ public class SentenceInter
     @Override
     public Collection<Link> searchLinks (SystemInfo system)
     {
-        if (role != TextRole.EndingNumber && role != TextRole.EndingText) {
-            return super.searchLinks(system);
-        }
+        // Look for the entity this sentence annotates
+        final Link link;
 
-        // Look for a suitable EndingInter
-        final Link link = lookupEndingLink(system);
+        switch (role) {
+            case EndingNumber, EndingText -> link = lookupEndingLink(system);
+            case RepeatCount -> link = lookupRepeatBarLink(system);
+            case null, default -> {
+                return super.searchLinks(system);
+            }
+        }
 
         return (link != null) ? Collections.singleton(link) : Collections.emptySet();
     }
@@ -680,6 +755,9 @@ public class SentenceInter
                 case EndingNumber, EndingText -> //
                         sig.getRelations(this, EndingSentenceRelation.class).forEach(
                                 rel -> sig.removeEdge(rel));
+
+                case RepeatCount -> sig.getRelations(this, RepeatCountRelation.class).forEach(
+                        rel -> sig.removeEdge(rel));
             }
         } catch (Exception ex) {
             logger.warn("Error in unlink for {} {}", this, ex.toString(), ex);
@@ -706,5 +784,22 @@ public class SentenceInter
                 line.getRole());
 
         return sentence;
+    }
+
+    //~ Inner Classes ------------------------------------------------------------------------------
+
+    //-----------//
+    // Constants //
+    //-----------//
+    private static class Constants
+            extends ConstantSet
+    {
+        private final Scale.Fraction maxRepeatCountDx = new Scale.Fraction(
+                3.0,
+                "Maximum abscissa shift between a right repeat and its repeat count");
+
+        private final Scale.Fraction maxRepeatCountDy = new Scale.Fraction(
+                6.0,
+                "Maximum ordinate gap between a right repeat and its repeat count");
     }
 }

--- a/app/src/main/java/org/audiveris/omr/sig/inter/StaffBarlineInter.java
+++ b/app/src/main/java/org/audiveris/omr/sig/inter/StaffBarlineInter.java
@@ -51,6 +51,7 @@ import org.audiveris.omr.sig.relation.Containment;
 import org.audiveris.omr.sig.relation.EndingBarRelation;
 import org.audiveris.omr.sig.relation.FermataBarRelation;
 import org.audiveris.omr.sig.relation.Relation;
+import org.audiveris.omr.sig.relation.RepeatCountRelation;
 import org.audiveris.omr.sig.relation.RepeatDotBarRelation;
 import org.audiveris.omr.sig.ui.AdditionTask;
 import org.audiveris.omr.sig.ui.UITask;
@@ -78,6 +79,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -112,6 +115,13 @@ public final class StaffBarlineInter
     //~ Static fields/initializers -----------------------------------------------------------------
 
     private static final Constants constants = new Constants();
+
+    /** Pattern of a printed repeat count, such as "x4" or "4x". */
+    private static final Pattern REPEAT_COUNT = Pattern.compile(
+            "(?:(?<prefix>\\d{1,2}) ?[xX])|(?:[xX] ?(?<suffix>\\d{1,2}))");
+
+    /** Smallest meaningful number of passes. */
+    private static final int MIN_REPEAT_COUNT = 2;
 
     private static final Logger logger = LoggerFactory.getLogger(StaffBarlineInter.class);
 
@@ -372,6 +382,28 @@ public final class StaffBarlineInter
 
             if (ebRel.getEndingSide() == side) {
                 return (EndingInter) sig.getOppositeInter(this, rel);
+            }
+        }
+
+        return null;
+    }
+
+    //----------------//
+    // getRepeatCount //
+    //----------------//
+    /**
+     * Report the number of passes printed for this barline, such as "x4".
+     *
+     * @return the repeat count, or null if none
+     */
+    public Integer getRepeatCount ()
+    {
+        for (Relation rel : sig.getRelations(this, RepeatCountRelation.class)) {
+            final SentenceInter sentence = (SentenceInter) sig.getOppositeInter(this, rel);
+            final Integer count = repeatCountOf(sentence.getValue());
+
+            if (count != null) {
+                return count;
             }
         }
 
@@ -1175,6 +1207,38 @@ public final class StaffBarlineInter
     public static Scale.Fraction getMaxStaffBarlineShift ()
     {
         return constants.maxStaffBarlineShift;
+    }
+
+    //---------------//
+    // repeatCountOf //
+    //---------------//
+    /**
+     * Parse the provided text as a repeat count, such as "x4" or "4x".
+     * <p>
+     * A bare number is rejected on purpose, because an ending number or a measure number
+     * would then be read as a count.
+     * A bare "x" is rejected as well, because it is a cross note head on a drum staff.
+     *
+     * @param value the text to parse, perhaps null
+     * @return the count value, or null if the text is not a repeat count
+     */
+    public static Integer repeatCountOf (String value)
+    {
+        if (value == null) {
+            return null;
+        }
+
+        final Matcher matcher = REPEAT_COUNT.matcher(value.trim());
+
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        final String digits = (matcher.group("prefix") != null) ? matcher.group("prefix")
+                : matcher.group("suffix");
+        final int count = Integer.parseInt(digits);
+
+        return (count >= MIN_REPEAT_COUNT) ? count : null;
     }
 
     //~ Inner Classes ------------------------------------------------------------------------------

--- a/app/src/main/java/org/audiveris/omr/sig/relation/Relations.java
+++ b/app/src/main/java/org/audiveris/omr/sig/relation/Relations.java
@@ -147,6 +147,7 @@ public abstract class Relations
         map(EndingInter.class, EndingBarRelation.class, BarlineInter.class); // Old
         map(EndingInter.class, EndingBarRelation.class, StaffBarlineInter.class);
         map(EndingInter.class, EndingSentenceRelation.class, SentenceInter.class);
+        map(StaffBarlineInter.class, RepeatCountRelation.class, SentenceInter.class);
 
         map(FermataInter.class, FermataBarRelation.class, BarlineInter.class); // Old
         map(FermataInter.class, FermataBarRelation.class, StaffBarlineInter.class);

--- a/app/src/main/java/org/audiveris/omr/sig/relation/RepeatCountRelation.java
+++ b/app/src/main/java/org/audiveris/omr/sig/relation/RepeatCountRelation.java
@@ -1,0 +1,55 @@
+//------------------------------------------------------------------------------------------------//
+//                                                                                                //
+//                            R e p e a t C o u n t R e l a t i o n                               //
+//                                                                                                //
+//------------------------------------------------------------------------------------------------//
+// <editor-fold defaultstate="collapsed" desc="hdr">
+//
+//  Copyright © Audiveris 2026. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the
+//  GNU Affero General Public License as published by the Free Software Foundation, either version
+//  3 of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License along with this
+//  program.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------------------------//
+// </editor-fold>
+package org.audiveris.omr.sig.relation;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Class <code>RepeatCountRelation</code> represents a support relation between a right repeat
+ * barline and the sentence that prints its number of passes, such as "x4" or "4x".
+ *
+ * @author Hervé Bitteur
+ */
+@XmlRootElement(name = "repeat-count")
+public class RepeatCountRelation
+        extends Support
+{
+    //~ Methods ------------------------------------------------------------------------------------
+
+    //----------------//
+    // isSingleSource //
+    //----------------//
+    @Override
+    public boolean isSingleSource ()
+    {
+        return true;
+    }
+
+    //----------------//
+    // isSingleTarget //
+    //----------------//
+    @Override
+    public boolean isSingleTarget ()
+    {
+        return true;
+    }
+}

--- a/app/src/main/java/org/audiveris/omr/text/TextRole.java
+++ b/app/src/main/java/org/audiveris/omr/text/TextRole.java
@@ -32,6 +32,7 @@ import org.audiveris.omr.sheet.Sheet;
 import org.audiveris.omr.sheet.Staff;
 import org.audiveris.omr.sheet.SystemInfo;
 import org.audiveris.omr.sig.inter.MetronomeInter;
+import org.audiveris.omr.sig.inter.StaffBarlineInter;
 import static org.audiveris.omr.util.HorizontalSide.LEFT;
 import static org.audiveris.omr.util.HorizontalSide.RIGHT;
 
@@ -80,6 +81,8 @@ public enum TextRole
     EndingText,
     /** Rehearsal mark, such as "Verse 1". */
     Rehearsal,
+    /** Repeat count, such as "x4" or "4x". */
+    RepeatCount,
     /** Metronome mark, such as "quarter = value". */
     Metronome;
 
@@ -137,6 +140,14 @@ public enum TextRole
 
         if (box == null) {
             return null;
+        }
+
+        // A single word such as "x4" or "4x" is a repeat count, whatever its location.
+        // Two words are refused, because on a drum staff a cross note head reads as an "x"
+        // and could pair with any number that OCR put on the same line.
+        if ((line.getWords().size() == 1) //
+                && (StaffBarlineInter.repeatCountOf(line.getValue()) != null)) {
+            return RepeatCount;
         }
 
         final Point2D boxCenter = GeoUtil.center2D(box);

--- a/app/src/test/java/org/audiveris/omr/sig/inter/StaffBarlineInterTest.java
+++ b/app/src/test/java/org/audiveris/omr/sig/inter/StaffBarlineInterTest.java
@@ -1,0 +1,84 @@
+//------------------------------------------------------------------------------------------------//
+//                                                                                                //
+//                          S t a f f B a r l i n e I n t e r T e s t                             //
+//                                                                                                //
+//------------------------------------------------------------------------------------------------//
+// <editor-fold defaultstate="collapsed" desc="hdr">
+//
+//  Copyright © Audiveris 2026. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the
+//  GNU Affero General Public License as published by the Free Software Foundation, either version
+//  3 of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License along with this
+//  program.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------------------------//
+// </editor-fold>
+package org.audiveris.omr.sig.inter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+
+/**
+ * Unitary tests for class <code>StaffBarlineInter</code>.
+ *
+ * @author Hervé Bitteur
+ */
+public class StaffBarlineInterTest
+{
+    //~ Constructors -------------------------------------------------------------------------------
+
+    public StaffBarlineInterTest ()
+    {
+    }
+
+    //~ Methods ------------------------------------------------------------------------------------
+
+    /**
+     * Test that the counts actually printed on a chart are read.
+     */
+    @Test
+    public void testRepeatCountAccepted ()
+    {
+        assertEquals(Integer.valueOf(4), StaffBarlineInter.repeatCountOf("x4"));
+        assertEquals(Integer.valueOf(4), StaffBarlineInter.repeatCountOf("X4"));
+        assertEquals(Integer.valueOf(4), StaffBarlineInter.repeatCountOf("4x"));
+        assertEquals(Integer.valueOf(4), StaffBarlineInter.repeatCountOf("4X"));
+        assertEquals(Integer.valueOf(4), StaffBarlineInter.repeatCountOf("x 4"));
+        assertEquals(Integer.valueOf(4), StaffBarlineInter.repeatCountOf("4 x"));
+        assertEquals(Integer.valueOf(19), StaffBarlineInter.repeatCountOf("19x"));
+        assertEquals(Integer.valueOf(2), StaffBarlineInter.repeatCountOf(" 2x "));
+    }
+
+    /**
+     * Test that whatever is not a printed count is refused.
+     */
+    @Test
+    public void testRepeatCountRefused ()
+    {
+        assertNull(StaffBarlineInter.repeatCountOf(null));
+        assertNull(StaffBarlineInter.repeatCountOf(""));
+
+        // A bare number is an ending number or a measure number
+        assertNull(StaffBarlineInter.repeatCountOf("4"));
+        assertNull(StaffBarlineInter.repeatCountOf("2."));
+
+        // A bare x is a cross note head
+        assertNull(StaffBarlineInter.repeatCountOf("x"));
+        assertNull(StaffBarlineInter.repeatCountOf("xx x x"));
+
+        // Playing once is not a repeat
+        assertNull(StaffBarlineInter.repeatCountOf("x1"));
+
+        // Prose is out of scope
+        assertNull(StaffBarlineInter.repeatCountOf("Play 4 times"));
+        assertNull(StaffBarlineInter.repeatCountOf("Fill 4"));
+        assertNull(StaffBarlineInter.repeatCountOf("4x4"));
+    }
+}


### PR DESCRIPTION
Part of #999

A repeat barline marked "x4" is exported as playing four times.

The OCR already reads the marking and keeps it as a sentence with no role. A one word sentence reading "x4" or "4x" now gets a new `TextRole.RepeatCount`, the LINKS step binds it to the nearest right repeat with a new `RepeatCountRelation`, and `PartwiseBuilder` sets `times` from it.

A bare number is refused, so an ending number or a measure number is never taken for a count. A bare "x" is refused too, since that is a cross note head on a drum staff, and two words are refused for the same reason. The bar has to be close, well inside the gap to the system above.

Prose such as "Play 4 times" is deliberately left out, so this is part of #999 rather than all of it. It is open ended and language dependent.

Over the drum charts I have here it sets the count on every repeat that prints one this way, and never sets one wrongly.
