### PR TITLE
Keep a system's first measure when a bar of staff follows the header

### DIFF
--- a/app/src/main/java/org/audiveris/omr/score/MeasureFixer.java
+++ b/app/src/main/java/org/audiveris/omr/score/MeasureFixer.java
@@ -21,9 +21,12 @@
 // </editor-fold>
 package org.audiveris.omr.score;
 
+import org.audiveris.omr.constant.ConstantSet;
 import org.audiveris.omr.math.Rational;
 import org.audiveris.omr.sheet.PartBarline;
+import org.audiveris.omr.sheet.Scale;
 import org.audiveris.omr.sheet.SystemInfo;
+import org.audiveris.omr.sheet.header.StaffHeader;
 import org.audiveris.omr.sheet.rhythm.Measure;
 import org.audiveris.omr.sheet.rhythm.MeasureStack;
 import org.audiveris.omr.sheet.rhythm.Voice;
@@ -54,6 +57,8 @@ import java.util.List;
 public class MeasureFixer
 {
     //~ Static fields/initializers -----------------------------------------------------------------
+
+    private static final Constants constants = new Constants();
 
     private static final Logger logger = LoggerFactory.getLogger(MeasureFixer.class);
 
@@ -159,7 +164,11 @@ public class MeasureFixer
     // isRealStart //
     //-------------//
     /**
-     * Check for a stack in second position, while following an empty stack
+     * Check for a stack in second position, while following a header stack.
+     * <p>
+     * A header is the clef, the key and the time and nothing after them. Where a bar
+     * of staff follows them, the stack is a measure, however little was recognised
+     * in it.
      *
      * @param stack the stack to check
      * @return true if so
@@ -168,7 +177,21 @@ public class MeasureFixer
     {
         final int im = stack.getSystem().getStacks().indexOf(stack);
 
-        return (im == 1) && isEmpty(prevStack);
+        if ((im != 1) || !isEmpty(prevStack)) {
+            return false;
+        }
+
+        final SystemInfo system = stack.getSystem();
+        final StaffHeader header = system.getFirstStaff().getHeader();
+
+        if (header == null) {
+            return true;
+        }
+
+        final Scale scale = system.getSheet().getScale();
+
+        return (prevStack.getRight() - header.stop) < scale.toPixels(
+                constants.minWidthAfterHeader);
     }
 
     //--------------------//
@@ -363,5 +386,18 @@ public class MeasureFixer
 
         // Side effect: remember the numeric value as last id
         lastId = id;
+    }
+
+    //~ Inner Classes ------------------------------------------------------------------------------
+
+    //-----------//
+    // Constants //
+    //-----------//
+    private static class Constants
+            extends ConstantSet
+    {
+        private final Scale.Fraction minWidthAfterHeader = new Scale.Fraction(
+                7.0,
+                "Minimum staff width past the header for the first stack to be a measure");
     }
 }


### PR DESCRIPTION
Fixes #1001

A first measure with nothing recognised in it is no longer merged into the second.

`isRealStart` treats a system's first stack as a header whenever it is empty. On a drum chart an opening bar with nothing recognised in it is ordinary, so that stack is a real measure. Neither what the stack holds nor how wide it is tells the two apart. A header prints inside the first measure, and both carry a clef and a time signature.

How much staff runs on past the header does tell them apart, and cleanly. Over the drum charts here every header stops within 4.6 interlines. Every real first measure runs past 11.5. The constant is 7.0, between them. It has to clear the wider figure because a staff with no clef printed has its header stop at the staff start, so the whole stack counts.

Measured on Audiveris' own stack counts, per sheet and per system. Eighteen systems gain a measure and none loses one. Each of the eighteen lands where a hand correction draws a bar.

EDIT: the constant was 4.0 when this was opened, and the body said the patch changed nothing else. Both were wrong and are corrected above.
