### PR TITLE
Hold original glyphs strongly so their IDs do not follow the collector

### DIFF
--- a/app/src/main/java/org/audiveris/omr/glyph/GlyphIndex.java
+++ b/app/src/main/java/org/audiveris/omr/glyph/GlyphIndex.java
@@ -89,8 +89,13 @@ public class GlyphIndex
     /** Underlying index to weak glyphs. */
     private final WeakGlyphIndex weakIndex = new WeakGlyphIndex();
 
-    /** Collection of original glyph instances, non sorted. */
-    private final ConcurrentHashMap<WeakGlyph, WeakGlyph> originals = new ConcurrentHashMap<>();
+    /**
+     * Collection of original glyph instances, non sorted.
+     * <p>
+     * These references are strong on purpose: held weakly, an entry could be collected between
+     * two identical glyphs and the second one would then be given an ID of its own.
+     */
+    private final ConcurrentHashMap<Glyph, Glyph> originals = new ConcurrentHashMap<>();
 
     /** Selection service, if any. */
     private GlyphService glyphService;
@@ -399,9 +404,7 @@ public class GlyphIndex
      */
     public synchronized Glyph registerOriginal (Glyph glyph)
     {
-        final WeakGlyph weak = new WeakGlyph(glyph);
-        final WeakGlyph orgWeak = originals.putIfAbsent(weak, weak);
-        final Glyph orgGlyph = (orgWeak != null) ? orgWeak.get() : null;
+        final Glyph orgGlyph = originals.putIfAbsent(glyph, glyph);
 
         if (orgGlyph == null) {
             privateRegister(glyph);
@@ -409,7 +412,7 @@ public class GlyphIndex
             return glyph;
         } else {
             logger.debug("Reuse original {}", orgGlyph);
-            weakIndex.insert(orgWeak); // Safer if original has been removed from index
+            weakIndex.insert(new WeakGlyph(orgGlyph)); // Safer if original left the index
 
             return orgGlyph;
         }
@@ -458,9 +461,8 @@ public class GlyphIndex
         }
 
         for (Glyph glyph : glyphs) {
-            WeakGlyph weak = new WeakGlyph(glyph);
-            weakIndex.insert(weak);
-            originals.putIfAbsent(weak, weak);
+            weakIndex.insert(new WeakGlyph(glyph));
+            originals.putIfAbsent(glyph, glyph);
         }
     }
 


### PR DESCRIPTION
Part of #1004

Two identical glyphs now always share one ID, whichever way the collector went.

`GlyphIndex.registerOriginal` de-duplicates through a map of weak references, so once an entry has been collected the next identical glyph is registered afresh and takes an ID of its own. The sheet's ID sequence then follows the collector rather than the page, and IDs break ties further down.

Keying the map on the glyph removes that. Equality is already by position and run table, which is what the lookup wanted, and the map still lives and dies with its sheet. The cost is that a sheet holds every distinct glyph it registered until it is swapped out.

Repairing `WeakGlyph.hashCode`, which changes once the referent is cleared and leaves the entry unfindable, would fix the lookup but not this bug: a glyph whose original has gone still takes an ID of its own.

Glyph and ID counts are now identical at every step, and the IDs in a saved sheet stop moving. Books still differ, since a second cause is left, but far less.
