### PR TITLE
Let a multiple rest support the measure count above it

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sig/relation/MultipleRestCountRelation.java
+++ b/app/src/main/java/org/audiveris/omr/sig/relation/MultipleRestCountRelation.java
@@ -21,6 +21,8 @@
 // </editor-fold>
 package org.audiveris.omr.sig.relation;
 
+import org.audiveris.omr.constant.Constant;
+import org.audiveris.omr.constant.ConstantSet;
 import org.audiveris.omr.sig.inter.Inter;
 import org.audiveris.omr.sig.inter.MeasureCountInter;
 import org.audiveris.omr.sig.inter.MultipleRestInter;
@@ -39,6 +41,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class MultipleRestCountRelation
         extends Support
 {
+    //~ Static fields/initializers -----------------------------------------------------------------
+
+    private static final Constants constants = new Constants();
+
     //~ Methods ------------------------------------------------------------------------------------
 
     //-------//
@@ -52,6 +58,15 @@ public class MultipleRestCountRelation
 
         final MeasureCountInter count = (MeasureCountInter) e.getEdgeTarget();
         count.checkAbnormal();
+    }
+
+    //----------------//
+    // getTargetCoeff //
+    //----------------//
+    @Override
+    protected double getTargetCoeff ()
+    {
+        return constants.countSupportCoeff.getValue();
     }
 
     //----------------//
@@ -89,5 +104,18 @@ public class MultipleRestCountRelation
         if (!count.isRemoved()) {
             count.checkAbnormal();
         }
+    }
+
+    //~ Inner Classes ------------------------------------------------------------------------------
+
+    //-----------//
+    // Constants //
+    //-----------//
+    private static class Constants
+            extends ConstantSet
+    {
+        private final Constant.Ratio countSupportCoeff = new Constant.Ratio(
+                5,
+                "Value for measure count coeff in support formula");
     }
 }


### PR DESCRIPTION
Fixes #1007

A multi-measure rest keeps the count it prints.

The count gets no support from the rest it is attached to. So it meets the weak-inter purge on the classifier's grade alone, and a printed digit is often not enough. `MultipleRestCountRelation` now gives it the coefficient a time number gets from its pair. Target side only, since the rest is found without the count.

Over the drum charts I have here it keeps counts that were being dropped. No measure edge moves. Some are still too weak. Others clear the purge and are then dropped for overlapping the OCR word that read the same digit, which is worth its own look.

`MeasureRepeatCountRelation` is in the same state and left alone. A repeat sign's count only restates its own slashes.
