### PR TITLE
Keep a barline from discarding a header time signature

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/time/HeaderTimeBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/time/HeaderTimeBuilder.java
@@ -43,6 +43,7 @@ import static org.audiveris.omr.sheet.time.TimeBuilder.TimeKind.DEN;
 import static org.audiveris.omr.sheet.time.TimeBuilder.TimeKind.NUM;
 import static org.audiveris.omr.sheet.time.TimeBuilder.TimeKind.WHOLE;
 import org.audiveris.omr.sig.inter.AbstractTimeInter;
+import org.audiveris.omr.sig.inter.BarlineInter;
 import org.audiveris.omr.sig.inter.Inter;
 import org.audiveris.omr.sig.inter.Inters;
 import org.audiveris.omr.sig.inter.TimeNumberInter;
@@ -214,6 +215,24 @@ public class HeaderTimeBuilder
                 adapter.cleanup();
             }
         }
+    }
+
+    //---------//
+    // canVeto //
+    //---------//
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A barline never gets a say here. A staff header holds none by definition, and
+     * {@link org.audiveris.omr.sheet.header.HeaderBuilder} deletes any that turns up inside one,
+     * but it does so only once clef, key and time have been retrieved. A vertical stroke picked
+     * up over the time signature would otherwise outgrade it and delete it for good, before the
+     * purge it is bound to lose to ever runs.
+     */
+    @Override
+    protected boolean canVeto (Inter neighbor)
+    {
+        return !(neighbor instanceof BarlineInter);
     }
 
     //---------------//

--- a/app/src/main/java/org/audiveris/omr/sheet/time/TimeBuilder.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/time/TimeBuilder.java
@@ -313,6 +313,20 @@ public abstract class TimeBuilder
         return timeInter;
     }
 
+    //---------//
+    // canVeto //
+    //---------//
+    /**
+     * Report whether an overlapping neighbor is entitled to discard a time candidate.
+     *
+     * @param neighbor the overlapping inter
+     * @return true if the neighbor may win over the time candidate
+     */
+    protected boolean canVeto (Inter neighbor)
+    {
+        return true;
+    }
+
     //-----------------//
     // settleConflicts //
     //-----------------//
@@ -337,7 +351,9 @@ public abstract class TimeBuilder
                 final Inter neighbor = itn.next();
 
                 if (neighbor.overlaps(time)) {
-                    if (neighbor.getGrade() <= timeGrade) {
+                    if (!canVeto(neighbor)) {
+                        itn.remove();
+                    } else if (neighbor.getGrade() <= timeGrade) {
                         if (neighbor.isVip()) {
                             logger.info("VIP Deleting {} overlapping {}", neighbor, time);
                         }


### PR DESCRIPTION
Summary

* `TimeBuilder.settleConflicts` no longer lets a barline discard a header time signature
* Time signatures found further down a staff keep their current behaviour, through a `canVeto` hook that only `HeaderTimeBuilder` overrides

Context

`HeaderBuilder.purgeBarlines` deletes any barline found inside a staff header, and `Staff.getHeaderStop` states that a header holds clef, key and time only. That purge runs after clef, key and time have been retrieved, so a spurious barline still gets its turn to outgrade a header time signature and delete it first.

On the sheet attached below, GRID reads the vertical alignment of the two digits of a 3/4 as a THIN_BARLINE of grade 0.408. The time signature scores 0.226, loses the overlap test, and is removed. The header then stops at the key signature, and HEADS goes on to read the two digits as three void note heads on a stem.

With the barline unable to veto, the time signature survives, the header extends over it, and purgeBarlines removes the barline as it was always meant to.

To reproduce

`bandurria1-bitonal.tif.zip` [1] is a 400 dpi bitonal sheet, one page of a scanned part. No settings changed:

```
audiveris -batch -transcribe -export bandurria1-bitonal.tif
```

Before, the exported MusicXML holds no time signature at all [2] . After, the first measure carries `3/4` [3].

The two screenshots are the logical view of that same sheet, before and after. `bandurria-1-view.pdf` [4] is there only to read the part, it will not reproduce the bug: Audiveris rasterises a PDF at its own resolution and the grades depend on the pixels.

The existing test suite stays green. I did not add a unit test: exercising the header step needs a full sheet fixture and the repository has no infrastructure for that.

[1] [bandurria1-bitonal.tif.zip](https://github.com/user-attachments/files/31686401/bandurria1-bitonal.tif.zip)


[2] <img width="722" height="262" alt="header-without-fix" src="https://github.com/user-attachments/assets/7dfc7715-838e-4741-a00d-3ece5aa9f964" />
[3] <img width="696" height="234" alt="header-with-fix" src="https://github.com/user-attachments/assets/08479f27-3b89-47c7-9ee5-13a410ca7c49" />

[4]  [bandurria-1-view.pdf](https://github.com/user-attachments/files/31686519/bandurria-1-view.pdf)
