### PR TITLE
Rename File->Input to File->Import files

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/ui/resources/BookActions.properties
+++ b/app/src/main/java/org/audiveris/omr/sheet/ui/resources/BookActions.properties
@@ -10,8 +10,8 @@
 
 # Menus
 
-inputHistory.text = Recent inputs
-inputHistory.toolTipText = History of most recent input files
+inputHistory.text = Recent files
+inputHistory.toolTipText = History of most recent source files
 inputHistory.icon = ${smallIcons}/apps/kfm.png
 
 bookHistory.text = Recent books
@@ -117,8 +117,8 @@ openBooks.Action.shortDescription = Load one or several books
 openBooks.Action.smallIcon = ${smallIcons}/filesystems/folder_music.png
 openBooks.Action.largeIcon = ${largeIcons}/filesystems/folder_music.png
 
-openImageFiles.Action.text = &Input...
-openImageFiles.Action.shortDescription = Open image files
+openImageFiles.Action.text = &Import files...
+openImageFiles.Action.shortDescription = Import image source files
 openImageFiles.Action.smallIcon = ${smallIcons}/filesystems/folder_images.png
 openImageFiles.Action.largeIcon = ${largeIcons}/filesystems/folder_images.png
 openImageFiles.Action.accelerator = control O
@@ -302,7 +302,7 @@ isDirectory.pattern = {0} is a directory.
 
 launchingBookSampleBrowser = Launching book sample browser...
 
-majorImageFiles = Major image files
+majorImageFiles = Common image files
 modified        = modified
 
 noBookRepo.pattern  = No specific sample repository for book {0}.

--- a/docs/_pages/reference/menus/file.md
+++ b/docs/_pages/reference/menus/file.md
@@ -16,12 +16,12 @@ Table of contents
 {:toc}
 ---
 
-## Recent inputs
+## Recent files
 
 Gives a list of the most recent image input files.
 A click on the file name opens the file as source image.
 
-## Input
+## Import files
 
 Opens a dialog box allowing to select the image or pdf-file that shall be transcribed.
 The dialog pre-selects the folder from where the last input image file was loaded.


### PR DESCRIPTION
Make small text changes to the File menu to be more intuitive, based on the following logic: we don't open an image file for editing, but rather we import it for processing to a different output format.

| Old name | New name |
| --- | --- |
| File -> Recent inputs | File -> Recent files |
| File -> Input | File -> Import files |
| Major image files | Common image files |

<img width="222" height="164" alt="image" src="https://github.com/user-attachments/assets/8f5ce198-b723-41f8-84b2-521af1fc6f46" />
