### PR TITLE
Add READY status for Step Monitor

### DIFF
--- a/app/src/main/java/org/audiveris/omr/step/ui/StepMonitor.java
+++ b/app/src/main/java/org/audiveris/omr/step/ui/StepMonitor.java
@@ -49,6 +49,9 @@ public class StepMonitor
 
     private static final Logger logger = LoggerFactory.getLogger(StepMonitor.class);
 
+    /** Text displayed when no step activity is going on. */
+    private static final String READY_TEXT = "READY";
+
     //~ Instance fields ----------------------------------------------------------------------------
 
     /** Progress bar for actions performed on sheet. */
@@ -65,11 +68,10 @@ public class StepMonitor
      */
     public StepMonitor ()
     {
-        bar.setToolTipText("On going Step activity");
+        bar.setToolTipText("Current step activity");
         bar.setStringPainted(true);
-        displayAnimation(false);
-        bar.setString("");
         bar.setForeground(Colors.PROGRESS_BAR);
+        displayAnimation(false);
     }
 
     //~ Methods ------------------------------------------------------------------------------------
@@ -128,6 +130,7 @@ public class StepMonitor
             if (actives <= 0) {
                 setBar(0);
                 SwingUtilities.invokeLater( () -> bar.setIndeterminate(false));
+                SwingUtilities.invokeLater( () -> bar.setString(READY_TEXT));
             }
         }
     }


### PR DESCRIPTION
When the step monitor is idle, the UI shows an empty box in the toolbar.

Add a READY text that displays in the step monitor every time there is nothing ongoing. This way it is more intuitive on what the space actually is there for and it also provides a quick update after the steps finish processing.

Also change the misspelled "On going Step activity" tooltip to "Current step activity".

<img width="479" height="62" alt="image" src="https://github.com/user-attachments/assets/0a7f01c2-e6b2-43c9-91a9-9df26b57dd47" />

This PR content improves UI introduced in #1027 
