### PR TITLE
Fix #979: Unicode characters stripped by JVM

### DIFF
--- a/app/src/main/java/Audiveris.java
+++ b/app/src/main/java/Audiveris.java
@@ -47,6 +47,88 @@ public final class Audiveris
      */
     public static void main (final String[] args)
     {
-        org.audiveris.omr.Main.main(args);
+        org.audiveris.omr.Main.main(fixWindowsArgs(args));
+    }
+
+    //-----------------//
+    // fixWindowsArgs  //
+    //-----------------//
+    /**
+     * On Windows, the JVM launcher builds <code>args</code> by converting the real
+     * (Unicode) command line into the process's legacy ANSI code page, <b>before</b>
+     * the JVM even starts. Characters not representable in that code page (e.g. 'ă' on
+     * a Western-European system) are silently best-fit mapped to a lookalike ASCII
+     * character, which then makes file lookups fail.
+     * <p>
+     * This cannot be fixed via JVM properties such as <code>sun.jnu.encoding</code>,
+     * since the corruption already happened at the OS/C-runtime level. Instead,
+     * re-fetch the true Unicode command line straight from Windows itself
+     * (<code>GetCommandLineW</code> + <code>CommandLineToArgvW</code>) and use its
+     * trailing tokens &mdash; token count and order are unaffected by the ANSI
+     * conversion, only the characters within a token are &mdash; as the real
+     * arguments.
+     *
+     * @param args the (possibly corrupted) arguments as provided by the JVM
+     * @return the corrected arguments on Windows, or the input unchanged otherwise
+     *         or on any failure to retrieve the native command line
+     */
+    private static String[] fixWindowsArgs (final String[] args)
+    {
+        if ((args.length == 0)
+                || !System.getProperty("os.name", "").toLowerCase().contains("windows")) {
+            return args;
+        }
+
+        com.sun.jna.Pointer argv = null;
+
+        try {
+            final com.sun.jna.WString cmdLine = Kernel32.INSTANCE.GetCommandLineW();
+            final com.sun.jna.ptr.IntByReference argc = new com.sun.jna.ptr.IntByReference();
+            argv = Shell32.INSTANCE.CommandLineToArgvW(cmdLine, argc);
+
+            if ((argv == null) || (argc.getValue() < args.length)) {
+                return args;
+            }
+
+            final int offset = argc.getValue() - args.length;
+            final String[] fixed = new String[args.length];
+
+            for (int i = 0; i < args.length; i++) {
+                final com.sun.jna.Pointer strPtr = argv.getPointer(
+                        (long) (offset + i) * com.sun.jna.Native.POINTER_SIZE);
+                fixed[i] = strPtr.getWideString(0);
+            }
+
+            return fixed;
+        } catch (Throwable ex) {
+            // JNA or native call unavailable/failed: fall back to the (possibly corrupted) args
+            return args;
+        } finally {
+            if (argv != null) {
+                Kernel32.INSTANCE.LocalFree(argv);
+            }
+        }
+    }
+
+    //~ Inner Interfaces -----------------------------------------------------------------------------
+
+    /** Minimal JNA binding for the needed kernel32 entries. */
+    private interface Kernel32 extends com.sun.jna.Library
+    {
+        Kernel32 INSTANCE = com.sun.jna.Native.load("kernel32", Kernel32.class);
+
+        com.sun.jna.WString GetCommandLineW ();
+
+        com.sun.jna.Pointer LocalFree (com.sun.jna.Pointer hMem);
+    }
+
+    /** Minimal JNA binding for the needed shell32 entries. */
+    private interface Shell32 extends com.sun.jna.Library
+    {
+        Shell32 INSTANCE = com.sun.jna.Native.load("shell32", Shell32.class);
+
+        com.sun.jna.Pointer CommandLineToArgvW (
+                com.sun.jna.WString cmdLine,
+                com.sun.jna.ptr.IntByReference pNumArgs);
     }
 }


### PR DESCRIPTION
On Windows, the JVM launcher builds `args` by converting the real (Unicode) command line into the process's legacy ANSI code page, *before* the JVM even starts. Characters not representable in that code page (e.g. 'ă' on a Western-European system) are silently best-fit mapped to a lookalike ASCII character, which then makes file lookups fail.

This cannot be fixed via JVM properties such as `sun.jnu.encoding`, since the corruption already happened at the OS/C-runtime level. Instead, re-fetch the true Unicode command line straight from Windows itself (`GetCommandLineW` + `CommandLineToArgvW`) and use its trailing tokens - token count and order are unaffected by the ANSI conversion, only the characters within a token are - as the real arguments.

On Linux systems, the arguments are passed as they are.