### PR TITLE
Change default page zoom to fit width

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/ui/StubsController.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/ui/StubsController.java
@@ -36,6 +36,7 @@ import org.audiveris.omr.ui.ViewParameters;
 import org.audiveris.omr.ui.selection.SelectionService;
 import org.audiveris.omr.ui.selection.StubEvent;
 import org.audiveris.omr.ui.util.WaitingTask;
+import org.audiveris.omr.ui.view.ScrollView;
 import org.audiveris.omr.util.OmrExecutors;
 
 import org.slf4j.Logger;
@@ -362,7 +363,14 @@ public class StubsController
                     if (stub == selected) {
                         // Tell the selected assembly that it now has the focus
                         // (to display stub related boards and error pane)
-                        stub.getAssembly().assemblySelected();
+                        SheetAssembly assembly = stub.getAssembly();
+                        assembly.assemblySelected();
+
+                        // Apply fit-to-width on initial display
+                        ScrollView scrollView = assembly.getSelectedScrollView();
+                        if (scrollView != null) {
+                            scrollView.fitWidth();
+                        }
 
                         // Stub status
                         BookActions.getInstance().updateProperties(stub.getSheet());


### PR DESCRIPTION
When opening an image or a saved omr file, the default zoom is 1x, which is not helpful at all, considering each one of us uses different monitor resolutions.

I am proposing changing the default zoom to fit page width by default, which makes the score immediately more accesible.

The user can change this at anytime as before.

Before:

<img width="1280" height="976" alt="image" src="https://github.com/user-attachments/assets/f44b907b-9358-43ad-abf9-761f6c8a77d1" />

After:

<img width="1280" height="976" alt="image" src="https://github.com/user-attachments/assets/0c4bb097-ffb8-4d06-a585-a7bf8c48c87c" />
