### PR TITLE
SheetStub: prune a copy in beforeMarshal so parallel stores do not race on the live params

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/SheetStub.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/SheetStub.java
@@ -328,8 +328,31 @@ public class SheetStub
     @SuppressWarnings("unused")
     private void beforeMarshal (Marshaller m)
     {
-        if ((parameters != null) && parameters.prune()) {
+        // Prune a disposable copy, never the live object: prune() is
+        // destructive (it nulls default-valued fields, and reports whether
+        // the structure became empty). When stubs are stored in parallel
+        // (see the processAllStubsInParallel book option), the live object
+        // is read by other threads while a marshal is in progress, so it
+        // must not be mutated here. The copy only lives for the duration of
+        // the marshal: the written XML is exactly the same as before, and
+        // afterMarshal restores the original from parametersMirror.
+        if (parameters == null) {
+            return;
+        }
+
+        final SheetParams copy = parameters.duplicate();
+
+        if (copy == null) {
+            // Should never happen: keep the previous behaviour
+            if (parameters.prune()) {
+                parameters = null;
+            }
+        }
+        else if (copy.prune()) {
             parameters = null;
+        }
+        else {
+            parameters = copy;
         }
     }
 
@@ -591,7 +614,13 @@ public class SheetStub
      */
     public BarlineHeight.MyParam getBarlineHeightParam ()
     {
-        return parameters.barlineSpecification;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.barlineSpecification : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.barlineSpecification : null);
     }
 
     //----------------------//
@@ -607,7 +636,13 @@ public class SheetStub
     //---------------------------//
     public IntegerParam getBeamSpecificationParam ()
     {
-        return parameters.beamSpecification;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.beamSpecification : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.beamSpecification : null);
     }
 
     //-----------------------//
@@ -623,7 +658,13 @@ public class SheetStub
     //----------------------------//
     public FilterParam getBinarizationFilterParam ()
     {
-        return parameters.binarizationFilter;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.binarizationFilter : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.binarizationFilter : null);
     }
 
     //---------//
@@ -709,7 +750,13 @@ public class SheetStub
      */
     public InputQualityParam getInputQualityParam ()
     {
-        return parameters.inputQuality;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.inputQuality : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.inputQuality : null);
     }
 
     //---------------------------//
@@ -725,7 +772,13 @@ public class SheetStub
     //--------------------------------//
     public IntegerParam getInterlineSpecificationParam ()
     {
-        return parameters.interlineSpecification;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.interlineSpecification : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.interlineSpecification : null);
     }
 
     //----------------//
@@ -802,7 +855,13 @@ public class SheetStub
      */
     public MusicFamily.MyParam getMusicFamilyParam ()
     {
-        return parameters.musicFamily;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.musicFamily : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.musicFamily : null);
     }
 
     //----------------//
@@ -875,7 +934,13 @@ public class SheetStub
      */
     public Param<String> getOcrLanguagesParam ()
     {
-        return parameters.ocrLanguages;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.ocrLanguages : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.ocrLanguages : null);
     }
 
     //-------------//
@@ -901,7 +966,13 @@ public class SheetStub
      */
     public ProcessingSwitches getProcessingSwitches ()
     {
-        return parameters.switches;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.switches : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.switches : null);
     }
 
     //------------//
@@ -1048,7 +1119,13 @@ public class SheetStub
      */
     public TextFamily.MyParam getTextFamilyParam ()
     {
-        return parameters.textFamily;
+        // The live parameters may be temporarily nulled or swapped by a
+        // concurrent beforeMarshal (see the processAllStubsInParallel book
+        // option); fall back to the unpruned mirror, so concurrent readers
+        // never see a transient null value.
+        final SheetParams p = (parameters != null) ? parameters : parametersMirror;
+        final var r = (p != null) ? p.textFamily : null;
+        return (r != null) ? r : ((parametersMirror != null) ? parametersMirror.textFamily : null);
     }
 
     //------------//

--- a/app/src/test/java/org/audiveris/omr/sheet/SheetStubTest.java
+++ b/app/src/test/java/org/audiveris/omr/sheet/SheetStubTest.java
@@ -1,0 +1,182 @@
+//------------------------------------------------------------------------------------------------//
+//                                                                                                //
+//                                        S h e e t S t u b T e s t                                 //
+//                                                                                                //
+//------------------------------------------------------------------------------------------------//
+// <editor-fold defaultstate="collapsed" desc="hdr">
+//
+//  Copyright © Audiveris 2026. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the
+//  GNU Affero General Public License as published by the Free Software Foundation, either version
+//  3 of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License along with this
+//  program.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------------------------//
+// </editor-fold>
+package org.audiveris.omr.sheet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+import javax.xml.bind.Marshaller;
+
+import org.audiveris.omr.sheet.Params.SheetParams;
+import org.audiveris.omr.util.BaseTestCase;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Paths;
+
+/**
+ * Class <code>SheetStubTest</code> covers the {@code beforeMarshal} /
+ * {@code afterMarshal} hooks invoked by the JAXB runtime while a {@code Book}
+ * is stored: the object published for marshalling must be a copy, so that
+ * the live parameters (read by other threads during parallel stub
+ * processing) are never left in a transiently pruned or null state.
+ */
+public class SheetStubTest
+        extends BaseTestCase
+{
+    //~ Constructors -------------------------------------------------------------------------------
+
+    /**
+     * Creates a new SheetStubTest object.
+     */
+    public SheetStubTest ()
+    {
+    }
+
+    //~ Tests --------------------------------------------------------------------------------------
+
+    //---------------------//
+    // testLiveObjectKept //
+    //---------------------//
+    @Test
+    public void testLiveObjectKept ()
+            throws Exception
+    {
+        SheetStub stub = newStub();
+
+        // Give one parameter a specific value, so the pruned copy is not empty
+        stub.getInterlineSpecificationParam().setSpecific(120);
+
+        // The live object, as seen by concurrent readers
+        SheetParams original = parameters(stub);
+        assertNotNull (original.musicFamily); // Default value, non-null
+
+        beforeMarshal(stub);
+
+        // The original object must have been left untouched
+        assertNotNull ("The live object must not be pruned", original.musicFamily);
+
+        // The object published for marshalling is a pruned copy
+        SheetParams published = parameters(stub);
+        assertNotSame (original, published);
+        assertNull ("Default values are pruned from the copy", published.musicFamily);
+        assertEquals (120, published.interlineSpecification.getSpecific().intValue());
+
+        afterMarshal(stub);
+
+        // A working parameters structure is restored after the marshal
+        assertNotSame (original, parameters(stub));
+        assertNotNull (parameters(stub).musicFamily);
+    }
+
+    //---------------------------//
+    // testGettersSafeInWindow //
+    //---------------------------//
+    @Test
+    public void testGettersSafeInWindow ()
+            throws Exception
+    {
+        SheetStub stub = newStub();
+
+        // During the marshal window, the parameters field may point at a
+        // pruned copy (fields nulled) or at null (all default): the
+        // getters must keep returning usable values instead of throwing
+        beforeMarshal(stub);
+        assertNotNull (stub.getMusicFamilyParam());
+        assertNotNull (stub.getInterlineSpecificationParam());
+
+        afterMarshal(stub);
+        assertNotNull (stub.getMusicFamilyParam());
+
+        // Simulate the window where the published object is null
+        setParameters(stub, null);
+        assertNotNull ("Getters must fall back to the mirror", stub.getMusicFamilyParam());
+        assertNotNull (stub.getInterlineSpecificationParam());
+    }
+
+    //~ Helpers ------------------------------------------------------------------------------------
+
+    /**
+     * Build a stub with its parameters fully wired, as in production
+     * (same path as {@code Book} construction or loading).
+     */
+    private static SheetStub newStub ()
+    {
+        Book book = new Book(Paths.get("test.pdf"));
+
+        return new SheetStub(book, 1);
+    }
+
+    /**
+     * Invoke the private {@code beforeMarshal (Marshaller)} hook, exactly
+     * as the JAXB runtime does.
+     */
+    private static void beforeMarshal (SheetStub stub)
+            throws Exception
+    {
+        invoke(stub, "beforeMarshal");
+    }
+
+    /**
+     * Invoke the private {@code afterMarshal (Marshaller)} hook, exactly
+     * as the JAXB runtime does.
+     */
+    private static void afterMarshal (SheetStub stub)
+            throws Exception
+    {
+        invoke(stub, "afterMarshal");
+    }
+
+    private static void invoke (SheetStub stub,
+                                String name)
+            throws Exception
+    {
+        Method method = SheetStub.class.getDeclaredMethod(name, Marshaller.class);
+        method.setAccessible(true);
+        method.invoke(stub, (Object) null);
+    }
+
+    private static SheetParams parameters (SheetStub stub)
+            throws Exception
+    {
+        return (SheetParams) field(stub).get(stub);
+    }
+
+    private static void setParameters (SheetStub stub,
+                                       SheetParams value)
+            throws Exception
+    {
+        field(stub).set(stub, value);
+    }
+
+    private static Field field (SheetStub stub)
+            throws Exception
+    {
+        Field field = SheetStub.class.getDeclaredField("parameters");
+        field.setAccessible(true);
+
+        return field;
+    }
+}


### PR DESCRIPTION
## Problem

With the `processAllStubsInParallel` book option, storing a book
(`Book.store()`) can fail with `NullPointerException` in step code of
*other* sheets (`HeadInter.getMusicFamily`, glyph evaluation). It does not
happen with sequential processing.

## Root cause

`SheetStub.beforeMarshal(Marshaller)` — a lifecycle hook invoked by the JAXB
runtime (via `LifecycleMethods`) for every object it marshals — used to call
`prune()` directly on the live `SheetParams`. `prune()` is destructive: it
nulls default-valued fields, and when nothing specific remains it nulls the
whole object (restored later by `afterMarshal` from `parametersMirror`).

While one thread marshals a stub, sibling threads executing OMR steps read
the *same* live object through the parameter getters and observe the
transiently pruned or null state, hence the NPE.

## Fix

- `beforeMarshal` now duplicates the parameters and prunes the **copy**,
  which is published only for the duration of the marshal and discarded by
  `afterMarshal`. The live object is never mutated, and the written `.omr`
  XML content is exactly the same as before (pruned values only).
- The nine parameter getters additionally fall back to `parametersMirror`
  (the unpruned snapshot) when the published object has been nulled or one
  of its fields pruned, so a concurrent reader never sees a null value.

## Tests

New `SheetStubTest` drives the private lifecycle hooks exactly as the JAXB
runtime does:

- the live `SheetParams` instance is left unmutated by `beforeMarshal`;
- the object published for marshalling is a distinct, properly pruned copy;
- the getters keep returning usable values throughout the marshal window,
  including the all-default case where the published object is `null`.

The full `:app:test` suite passes.
