### PR TITLE
Marshal a pruned copy of the parameters for batch mode

### DIFF
--- a/app/src/main/java/org/audiveris/omr/sheet/Book.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/Book.java
@@ -180,9 +180,18 @@ public class Book
     /**
      * All Book parameters, editable via the BookParameters dialog.
      * This structure replaces the deprecated individual Param instances.
+     * <p>
+     * This live structure is populated by {@link #afterUnmarshal} and is never touched by JAXB
+     * afterwards, so that it can be read at any time, even while the book is being stored.
+     */
+    private BookParams parameters;
+
+    /**
+     * Pruned copy of {@link #parameters}, limited to the params with a specific value.
+     * It exists only while this object is being marshalled or unmarshalled.
      */
     @XmlElement(name = "parameters")
-    private BookParams parameters;
+    private BookParams xmlParameters;
 
     /**
      * This string, if any, is a specification of sheets selection.
@@ -262,9 +271,6 @@ public class Book
 
     /** Active parameter dialog, if any. */
     private JDialog parameterDialog;
-
-    /** A trick to keep parameters intact, even when nullified at marshal time. */
-    private BookParams parametersMirror;
 
     /** Has the book itself been upgraded?. */
     private boolean bookUpgraded = false;
@@ -348,7 +354,18 @@ public class Book
     @SuppressWarnings("unused")
     private void afterMarshal (Marshaller m)
     {
-        parameters = parametersMirror.duplicate();
+        xmlParameters = null;
+    }
+
+    //----------------//
+    // afterUnmarshal //
+    //----------------//
+    @SuppressWarnings("unused")
+    private void afterUnmarshal (Unmarshaller u,
+                                 Object parent)
+    {
+        parameters = xmlParameters;
+        xmlParameters = null;
     }
 
     //----------//
@@ -398,8 +415,12 @@ public class Book
     @SuppressWarnings("unused")
     private void beforeMarshal (Marshaller m)
     {
-        if ((parameters != null) && parameters.prune()) {
-            parameters = null;
+        // Marshal a pruned copy, so that the live parameters remain available to the other
+        // threads (sheets may be processed in parallel while the book is being stored)
+        xmlParameters = (parameters != null) ? parameters.duplicate() : null;
+
+        if ((xmlParameters != null) && xmlParameters.prune()) {
+            xmlParameters = null;
         }
     }
 
@@ -2320,9 +2341,6 @@ public class Book
 
         // 2/ set parents
         parameters.setParents(null);
-
-        // 3/ set parametersMirror
-        parametersMirror = parameters.duplicate();
     }
 
     //------------------//

--- a/app/src/main/java/org/audiveris/omr/sheet/SheetStub.java
+++ b/app/src/main/java/org/audiveris/omr/sheet/SheetStub.java
@@ -86,6 +86,7 @@ import java.util.function.Predicate;
 import javax.swing.SwingUtilities;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -158,9 +159,18 @@ public class SheetStub
     /**
      * All SheetStub parameters, editable via the BookParameters dialog.
      * This structure replaces the deprecated individual Param instances.
+     * <p>
+     * This live structure is populated by {@link #afterUnmarshal} and is never touched by JAXB
+     * afterwards, so that it can be read at any time, even while the book is being stored.
+     */
+    private SheetParams parameters;
+
+    /**
+     * Pruned copy of {@link #parameters}, limited to the params with a specific value.
+     * It exists only while this object is being marshalled or unmarshalled.
      */
     @XmlElement(name = "parameters")
-    private SheetParams parameters;
+    private SheetParams xmlParameters;
 
     /**
      * This is the sequence of steps already performed on this sheet.
@@ -199,9 +209,6 @@ public class SheetStub
 
     /** Related assembly instance, if any. */
     private SheetAssembly assembly;
-
-    /** A trick to keep parameters intact, even when nullified at marshal time. */
-    private SheetParams parametersMirror;
 
     // Deprecated persistent data
     //---------------------------
@@ -319,7 +326,18 @@ public class SheetStub
     @SuppressWarnings("unused")
     private void afterMarshal (Marshaller m)
     {
-        parameters = parametersMirror.duplicate();
+        xmlParameters = null;
+    }
+
+    //----------------//
+    // afterUnmarshal //
+    //----------------//
+    @SuppressWarnings("unused")
+    private void afterUnmarshal (Unmarshaller u,
+                                 Object parent)
+    {
+        parameters = xmlParameters;
+        xmlParameters = null;
     }
 
     //---------------//
@@ -328,8 +346,12 @@ public class SheetStub
     @SuppressWarnings("unused")
     private void beforeMarshal (Marshaller m)
     {
-        if ((parameters != null) && parameters.prune()) {
-            parameters = null;
+        // Marshal a pruned copy, so that the live parameters remain available to the other
+        // threads (sheets may be processed in parallel while the book is being stored)
+        xmlParameters = (parameters != null) ? parameters.duplicate() : null;
+
+        if ((xmlParameters != null) && xmlParameters.prune()) {
+            xmlParameters = null;
         }
     }
 
@@ -1551,9 +1573,6 @@ public class SheetStub
 
         // 2/ set parents
         parameters.setParents(book);
-
-        // 3/ set parametersMirror
-        parametersMirror = parameters.duplicate();
     }
 
     //---------------//

--- a/app/src/test/java/org/audiveris/omr/sheet/ParametersMarshalTest.java
+++ b/app/src/test/java/org/audiveris/omr/sheet/ParametersMarshalTest.java
@@ -1,0 +1,81 @@
+//------------------------------------------------------------------------------------------------//
+//                                                                                                //
+//                           P a r a m e t e r s M a r s h a l T e s t                            //
+//                                                                                                //
+//------------------------------------------------------------------------------------------------//
+// <editor-fold defaultstate="collapsed" desc="hdr">
+//
+//  Copyright © Audiveris 2026. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the
+//  GNU Affero General Public License as published by the Free Software Foundation, either version
+//  3 of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License along with this
+//  program.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------------------------//
+// </editor-fold>
+package org.audiveris.omr.sheet;
+
+import org.audiveris.omr.util.BaseTestCase;
+import org.audiveris.omr.util.Jaxb;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Checks that the parameters of a book and of its stubs can be read at any time,
+ * even while the book is being marshalled by another thread, as happens when sheets
+ * are processed in parallel and each of them stores the book.
+ */
+public class ParametersMarshalTest
+        extends BaseTestCase
+{
+    private static final int MARSHAL_COUNT = 200;
+
+    @Test
+    public void testParametersReadableWhileMarshalling ()
+        throws Exception
+    {
+        final Book book = new Book(Paths.get("dummy.png")); // The path is never opened
+        book.addStub(new SheetStub(book, 1));
+        book.addStub(new SheetStub(book, 2));
+        final SheetStub stub = book.getStubs().get(1);
+
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final Thread reader = new Thread( () -> {
+            try {
+                while (!stop.get()) {
+                    stub.getInputQualityParam().getValue();
+                    stub.getMusicFamilyParam().getValue();
+                    book.getOcrLanguagesParam().getValue();
+                }
+            } catch (Throwable ex) {
+                failure.set(ex);
+            }
+        }, "parameters-reader");
+        reader.start();
+
+        try {
+            for (int i = 0; (i < MARSHAL_COUNT) && (failure.get() == null); i++) {
+                Jaxb.marshal(book, new ByteArrayOutputStream(), Book.getJaxbContext());
+            }
+        } finally {
+            stop.set(true);
+            reader.join();
+        }
+
+        if (failure.get() != null) {
+            throw new AssertionError("Parameters not readable while marshalling", failure.get());
+        }
+    }
+}


### PR DESCRIPTION
This change fixes #1032 

**Issue**
`Book.beforeMarshal` and `SheetStub.beforeMarshal` set the live `parameters` field to null while the book is being marshalled, so that only the params with a specific value are written (and no element when there are none); `afterMarshal` restores the field from a mirror. With `processAllStubsInParallel` every sheet task stores the book while the others are still running and read a null field or pruned members: the `NullPointerException` from #A.

**Fix**
Now JAXB never touches the live structure. A separate `xmlParameters` field carries the XML element: `beforeMarshal` fills it with a pruned duplicate (the params objects are shared, only the container is copied), `afterMarshal` clears it, and `afterUnmarshal` moves a loaded structure into `parameters`. The mirror fields are no longer needed. book.xml comes out exactly as before (same element, same position, still omitted when empty), and an exception during marshalling can no longer leave `parameters` null.

**Test (2nd commit)**
`ParametersMarshalTest` triggers the race every time (a reader thread against 200 marshals); it fails on `development` and passes with this change. 

A related pr is #1029.