### PR TITLE
Synchronize the shared SimpleDateFormat of Constant.Date

### DIFF
--- a/app/src/main/java/org/audiveris/omr/constant/Constant.java
+++ b/app/src/main/java/org/audiveris/omr/constant/Constant.java
@@ -604,6 +604,7 @@ public abstract class Constant<E>
     public static class Date
             extends Constant<java.util.Date>
     {
+        /** Shared formatter; SimpleDateFormat is not thread-safe, hence the synchronization. */
         private static final DateFormat DATE_FORMAT = new SimpleDateFormat(
                 "dd-MMM-yyyy",
                 Locale.US);
@@ -625,7 +626,9 @@ public abstract class Constant<E>
         protected java.util.Date decode (java.lang.String str)
         {
             try {
-                return DATE_FORMAT.parse(str);
+                synchronized (DATE_FORMAT) {
+                    return DATE_FORMAT.parse(str);
+                }
             } catch (ParseException ex) {
                 logger.error("Error parsing {}", str, ex);
 
@@ -647,7 +650,9 @@ public abstract class Constant<E>
         public static java.util.Date decodeDate (java.lang.String str)
         {
             try {
-                return DATE_FORMAT.parse(str);
+                synchronized (DATE_FORMAT) {
+                    return DATE_FORMAT.parse(str);
+                }
             } catch (ParseException ex) {
                 logger.error("Error parsing {}", str, ex);
 
@@ -657,7 +662,9 @@ public abstract class Constant<E>
 
         public static java.lang.String encode (java.util.Date date)
         {
-            return DATE_FORMAT.format(date);
+            synchronized (DATE_FORMAT) {
+                return DATE_FORMAT.format(date);
+            }
         }
     }
 


### PR DESCRIPTION
While chasing #1032 I noticed that with `processAllStubsInParallel` the log shows, several times per run:

```
WARN  Constant 417 | Error registering constant org.audiveris.omr.sheet.Versions.lastReleaseCheckDate
java.lang.NumberFormatException: For input string: "."
    at java.text.SimpleDateFormat.parse(SimpleDateFormat.java:1579)
    at org.audiveris.omr.constant.Constant$Date.decode(Constant.java:628)
```

`Constant.Date` parses and formats through one static `SimpleDateFormat`, which is not thread-safe. The sheet threads trigger the lazy registration of `Versions.lastReleaseCheckDate` at the same moment and corrupt each other's parse. 

Parsing and formatting now lock the shared formatter, and the warnings are gone.