### PR TITLE
Modern UI: Add Dark theme

### DIFF
--- a/app/src/main/java/org/audiveris/omr/ui/MainGui.java
+++ b/app/src/main/java/org/audiveris/omr/ui/MainGui.java
@@ -51,6 +51,7 @@ import org.audiveris.omr.ui.selection.StubEvent;
 import org.audiveris.omr.ui.symbol.MusicFont;
 import org.audiveris.omr.ui.util.ModelessOptionPane;
 import org.audiveris.omr.ui.util.SeparableMenu;
+import org.audiveris.omr.ui.util.UILookAndFeel;
 import org.audiveris.omr.ui.util.UIUtil;
 import org.audiveris.omr.util.OmrExecutors;
 import org.audiveris.omr.util.WeakPropertyChangeListener;
@@ -424,6 +425,9 @@ public class MainGui
     protected void initialize (String[] args)
     {
         logger.debug("MainGui. 1/initialize");
+
+        // Apply UI theme from preferences before other UI initialization
+        UILookAndFeel.setUI(null);
 
         // Select proper fonts names and sizes.
         // NOTA: This must take place after the look and feel has been set (see Application.create()),

--- a/app/src/main/java/org/audiveris/omr/ui/action/Preferences.java
+++ b/app/src/main/java/org/audiveris/omr/ui/action/Preferences.java
@@ -30,6 +30,7 @@ import org.audiveris.omr.sheet.ui.StubsController;
 import org.audiveris.omr.step.OmrStep;
 import org.audiveris.omr.ui.util.Panel;
 import org.audiveris.omr.ui.util.UIUtil;
+import org.audiveris.omr.ui.util.UILookAndFeel;
 import org.audiveris.omr.util.LabeledEnum;
 
 import org.jdesktop.application.Application;
@@ -169,7 +170,7 @@ public abstract class Preferences
                     "6dlu" // Title height
                             + ",pref" // Scaling
                             + ",1dlu,pref" // Locale
-                            + ",1dlu,pref" // Topic
+                            + ",1dlu,pref" // Theme
                             + ",1dlu,pref" // Topic
                             + ",1dlu,pref" // Topic
                             + ",1dlu,pref" // Topic
@@ -185,6 +186,9 @@ public abstract class Preferences
 
             // Locale
             builder.addRaw(new LocalePane()).xy(1, r += 2);
+
+            // Theme selection
+            builder.addRaw(new ThemePane()).xy(1, r += 2);
 
             // Advanced switches
             for (Topic topic : Topic.values()) {
@@ -751,6 +755,64 @@ public abstract class Preferences
         {
             final JCheckBox box = (JCheckBox) e.getSource();
             topic.set(box.isSelected());
+        }
+    }
+
+    //-----------//
+    // ThemePane //
+    //-----------//
+    /**
+     * Handling of theme selection.
+     */
+    private static class ThemePane
+            extends Panel
+            implements ActionListener
+    {
+        private final JComboBox<String> themeBox;
+
+        public ThemePane ()
+        {
+            final String className = getClass().getSimpleName();
+            final String tip = resources.getString(className + ".titledBorder.text");
+
+            // Define themeBox
+            themeBox = new JComboBox<>(new String[] {
+                    "Light",
+                    "Dark"
+            });
+            themeBox.addActionListener(this);
+
+            // Layout
+            final FormLayout layout = new FormLayout(columnSpecs, "fill:pref");
+            final FormBuilder builder = FormBuilder.create().layout(layout).panel(this);
+            builder.addRaw(themeBox).xyw(1, 1, 3);
+            builder.addRaw(new JLabel(tip)).xy(5, 1);
+
+            // Set current value
+            String currentTheme = UILookAndFeel.getThemeName();
+            if ("com.formdev.flatlaf.FlatDarkLaf".equals(currentTheme)) {
+                themeBox.setSelectedIndex(1);
+            } else {
+                themeBox.setSelectedIndex(0);
+            }
+        }
+
+        @Override
+        public void actionPerformed (ActionEvent e)
+        {
+            String selectedTheme = (String) themeBox.getSelectedItem();
+            if ("Dark".equals(selectedTheme)) {
+                UILookAndFeel.setUI("com.formdev.flatlaf.FlatDarkLaf");
+            } else {
+                UILookAndFeel.setUI("com.formdev.flatlaf.FlatLightLaf");
+            }
+        }
+
+        @Override
+        public void setEnabled (boolean enabled)
+        {
+            super.setEnabled(enabled);
+            themeBox.setEnabled(enabled);
         }
     }
 }

--- a/app/src/main/java/org/audiveris/omr/ui/action/resources/Preferences.properties
+++ b/app/src/main/java/org/audiveris/omr/ui/action/resources/Preferences.properties
@@ -66,3 +66,8 @@ ScalingPane.slider.text = Font size
 #------------
 
 LocalePane.localeBox.toolTipText = Locale chosen for application
+
+# ThemePane
+#----------
+
+ThemePane.titledBorder.text = Application Theme

--- a/app/src/main/java/org/audiveris/omr/ui/action/resources/Preferences_fr.properties
+++ b/app/src/main/java/org/audiveris/omr/ui/action/resources/Preferences_fr.properties
@@ -80,3 +80,8 @@ ScalingPane.slider.text = Taille de caract\u00e8res
 #------------
 
 LocalePane.localeBox.toolTipText = Langue locale utilis\u00e9e par l'application
+
+# ThemePane
+#----------
+
+ThemePane.titledBorder.text = Th\u00e8me de l'interface

--- a/app/src/main/java/org/audiveris/omr/ui/resources/MainGui.properties
+++ b/app/src/main/java/org/audiveris/omr/ui/resources/MainGui.properties
@@ -22,9 +22,6 @@ Application.vendorId = AudiverisLtd
 Application.icon = icon-24.png
 
 Application.lookAndFeel = com.formdev.flatlaf.FlatLightLaf
-#Application.lookAndFeel = com.formdev.flatlaf.FlatDarkLaf
-#Application.lookAndFeel = javax.swing.plaf.metal.MetalLookAndFeel
-#Application.lookAndFeel = Nimbus
 
 # Application.vendor is only displayed in About box
 Application.vendor = Audiveris Ltd.

--- a/app/src/main/java/org/audiveris/omr/ui/util/UILookAndFeel.java
+++ b/app/src/main/java/org/audiveris/omr/ui/util/UILookAndFeel.java
@@ -94,6 +94,19 @@ public class UILookAndFeel
         }
     }
 
+    //--------------//
+    // getThemeName //
+    //--------------//
+    /**
+     * Get the current theme name as a string.
+     *
+     * @return the full class name of the current look and feel
+     */
+    public static String getThemeName ()
+    {
+        return constants.lookAndFeel.getValue();
+    }
+
     //~ Inner Classes ------------------------------------------------------------------------------
 
     //-----------//


### PR DESCRIPTION
Implement a selector in the Preferences dialog for the user to be able to choose between the Light and Dark default FlatLaf themes.

Initial look & feel of the Dark Theme (needs more adjusting of text colors and UI components in a future PR):

<img width="1280" height="976" alt="Screenshot 2026-09-11 200050" src="https://github.com/user-attachments/assets/41f05bb1-8b49-435b-83f7-03b371415bfb" />

The Preferences dialog:

<img width="778" height="1033" alt="Screenshot 2026-09-11 200614" src="https://github.com/user-attachments/assets/797aee73-f71d-4c3c-bb6b-e3e6eedfb8c7" />
